### PR TITLE
Jeageun/mdlcsr construct construct

### DIFF
--- a/include/pando-lib-galois/graphs/dist_local_csr.hpp
+++ b/include/pando-lib-galois/graphs/dist_local_csr.hpp
@@ -100,12 +100,12 @@ public:
     VertexIt& operator++() {
       auto currNode = static_cast<std::uint64_t>(galois::localityOf(m_pos).node.id);
       pointer ptr = m_pos + 1;
-      CSR csrCurr = arrayOfCSRs.get(currNode);
+      CSR csrCurr = arrayOfCSRs[currNode];
       if (csrCurr.vertexEdgeOffsets.end() - 1 > ptr ||
           (int16_t)currNode == pando::getPlaceDims().node.id - 1) {
         m_pos = ptr;
       } else {
-        csrCurr = arrayOfCSRs.get(currNode + 1);
+        csrCurr = arrayOfCSRs[currNode + 1];
         this->m_pos = csrCurr.vertexEdgeOffsets.begin();
       }
       return *this;
@@ -403,7 +403,7 @@ public:
     std::uint64_t physicalHost = fmap(virtualToPhysicalMap.getLocalRef(), get, virtualHostID);
     auto [ret, found] = fmap(getLocalCSR(), relaxedgetTopologyID, tid);
     if (!found) {
-      return fmap(arrayOfCSRs.get(physicalHost), getTopologyID, tid);
+      return fmap(arrayOfCSRs[physicalHost], getTopologyID, tid);
     } else {
       return ret;
     }
@@ -1148,7 +1148,7 @@ public:
    */
   pando::GlobalRef<CSR> getLocalCSR() {
     std::uint64_t nodeIdx = static_cast<std::uint64_t>(pando::getCurrentPlace().node.id);
-    return arrayOfCSRs.get(nodeIdx);
+    return arrayOfCSRs[nodeIdx];
   }
 
 private:

--- a/include/pando-lib-galois/graphs/dist_local_csr.hpp
+++ b/include/pando-lib-galois/graphs/dist_local_csr.hpp
@@ -408,6 +408,10 @@ public:
       return ret;
     }
   }
+
+private:
+  // This function is for mirrored dist local csr, or classes which will directly use it. Don't use
+  // it externally. getLocalTopologyID with non-existing tokenID will return failure.
   VertexTopologyID getLocalTopologyID(VertexTokenID tid) {
     return fmap(getLocalCSR(), getTopologyID, tid);
   }
@@ -417,6 +421,7 @@ public:
     return fmap(arrayOfCSRs[physicalHost], getTopologyID, tid);
   }
 
+public:
   VertexTopologyID getTopologyIDFromIndex(std::uint64_t index) {
     std::uint64_t hostNum = 0;
     std::uint64_t hostSize;

--- a/include/pando-lib-galois/graphs/graph_traits.hpp
+++ b/include/pando-lib-galois/graphs/graph_traits.hpp
@@ -196,5 +196,26 @@ struct graph_checker {
       sizeof(addEdgesTopologyOnly(0)) == sizeof(Yes) && sizeof(addEdges(0)) == sizeof(Yes) &&
       sizeof(deleteEdges(0)) == sizeof(Yes);
 };
+
+/**
+ * @brief this is the graph interface, methods from here should mostly be used
+ */
+template <typename G, typename VertexTokenID, typename VertexTopologyID, typename EdgeHandle,
+          typename VertexData, typename EdgeData, typename VertexRange, typename EdgeRange,
+          typename VertexDataRange, typename EdgeDataRange>
+struct gluon_graph {
+  /** Size **/
+  std::uint64_t getMasterSize();
+  std::uint64_t getMasterSize() const noexcept;
+  std::uint64_t getMirrorSize();
+  std::uint64_t getMirrorSize() const noexcept;
+
+  /** Range **/
+  VertexRange getMasterRange();
+  VertexRange getMirrorRange();
+
+  /** Sync **/
+  // template <typename Func> pando::Array<bool> sync(Func func, pando::Array<bool>);
+};
 } // namespace galois
 #endif // PANDO_LIB_GALOIS_GRAPHS_GRAPH_TRAITS_HPP_

--- a/include/pando-lib-galois/graphs/local_csr.hpp
+++ b/include/pando-lib-galois/graphs/local_csr.hpp
@@ -428,6 +428,8 @@ public:
   VertexTopologyID getTopologyID(VertexTokenID token) {
     pando::GlobalPtr<Vertex> ret;
     if (!tokenToTopology.get(token, ret)) {
+      std::cout << "In the host " << pando::getCurrentPlace().node.id
+                << "can't find token:" << token << std::endl;
       PANDO_ABORT("FAILURE TO FIND TOKENID");
     }
     return ret;

--- a/include/pando-lib-galois/graphs/local_csr.hpp
+++ b/include/pando-lib-galois/graphs/local_csr.hpp
@@ -9,6 +9,8 @@
 #include <pando-lib-galois/containers/hashtable.hpp>
 #include <pando-lib-galois/graphs/graph_traits.hpp>
 #include <pando-lib-galois/loops/do_all.hpp>
+#include <pando-lib-galois/utility/pair.hpp>
+#include <pando-lib-galois/utility/tuple.hpp>
 #include <pando-rt/containers/array.hpp>
 #include <pando-rt/pando-rt.hpp>
 
@@ -234,9 +236,13 @@ template <typename VertexType, typename EdgeType>
 class DistLocalCSR;
 
 template <typename VertexType, typename EdgeType>
+class MirrorDistLocalCSR;
+
+template <typename VertexType, typename EdgeType>
 class LCSR {
 public:
   friend DistLocalCSR<VertexType, EdgeType>;
+  friend MirrorDistLocalCSR<VertexType, EdgeType>;
   using VertexTokenID = std::uint64_t;
   using VertexTopologyID = pando::GlobalPtr<Vertex>;
   using EdgeHandle = pando::GlobalPtr<HalfEdge>;
@@ -409,6 +415,16 @@ public:
   }
 
   /** Vertex Manipulation **/
+private:
+  // Use with your own risk.
+  // It is reasonable only when you could handle the non-existing value outside of this function.
+  galois::Pair<VertexTopologyID, bool> relaxedgetTopologyID(VertexTokenID token) {
+    pando::GlobalPtr<Vertex> ret;
+    bool found = tokenToTopology.get(token, ret);
+    return galois::make_tpl(ret, found);
+  }
+
+public:
   VertexTopologyID getTopologyID(VertexTokenID token) {
     pando::GlobalPtr<Vertex> ret;
     if (!tokenToTopology.get(token, ret)) {

--- a/include/pando-lib-galois/graphs/mirror_dist_local_csr.hpp
+++ b/include/pando-lib-galois/graphs/mirror_dist_local_csr.hpp
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2023. University of Texas at Austin. All rights reserved.
+
+#ifndef PANDO_LIB_GALOIS_GRAPHS_MIRROR_DIST_LOCAL_CSR_HPP_
+#define PANDO_LIB_GALOIS_GRAPHS_MIRROR_DIST_LOCAL_CSR_HPP_
+
+#include <pando-rt/export.h>
+
+#include <utility>
+
+#include "pando-rt/sync/mutex.hpp"
+#include <pando-lib-galois/containers/hashtable.hpp>
+#include <pando-lib-galois/containers/host_indexed_map.hpp>
+#include <pando-lib-galois/containers/host_local_storage.hpp>
+#include <pando-lib-galois/containers/per_thread.hpp>
+#include <pando-lib-galois/graphs/dist_local_csr.hpp>
+#include <pando-lib-galois/graphs/local_csr.hpp>
+#include <pando-lib-galois/import/wmd_graph_importer.hpp>
+#include <pando-lib-galois/loops/do_all.hpp>
+#include <pando-lib-galois/utility/gptr_monad.hpp>
+#include <pando-rt/containers/array.hpp>
+#include <pando-rt/containers/vector.hpp>
+#include <pando-rt/memory/memory_guard.hpp>
+#include <pando-rt/pando-rt.hpp>
+
+#define FREE 1
+
+namespace galois {
+
+namespace internal {
+
+template <typename VertexType, typename EdgeType>
+struct MDLCSR_InitializeState {
+  using CSR = LCSR<VertexType, EdgeType>;
+
+  MDLCSR_InitializeState() = default;
+  MDLCSR_InitializeState(galois::HostIndexedMap<CSR> arrayOfCSRs_,
+                         galois::PerThreadVector<VertexType> vertices_,
+                         galois::PerThreadVector<EdgeType> edges_,
+                         galois::PerThreadVector<uint64_t> edgeCounts_)
+      : arrayOfCSRs(arrayOfCSRs_), vertices(vertices_), edges(edges_), edgeCounts(edgeCounts_) {}
+
+  galois::HostIndexedMap<CSR> arrayOfCSRs;
+  galois::PerThreadVector<VertexType> vertices;
+  galois::PerThreadVector<EdgeType> edges;
+  galois::PerThreadVector<uint64_t> edgeCounts;
+};
+
+} // namespace internal
+
+template <typename VertexType = WMDVertex, typename EdgeType = WMDEdge>
+class MirrorDistLocalCSR {
+public:
+  using VertexTokenID = std::uint64_t;
+  using VertexTopologyID = pando::GlobalPtr<Vertex>;
+  using EdgeHandle = pando::GlobalPtr<HalfEdge>;
+  using VertexData = VertexType;
+  using EdgeData = EdgeType;
+  using EdgeRange = RefSpan<HalfEdge>;
+  using EdgeDataRange = pando::Span<EdgeData>;
+  using CSR = LCSR<VertexType, EdgeType>;
+  using DLCSR = DistLocalCSR<VertexType, EdgeType>;
+  using VertexRange = typename DLCSR::VertexRange;
+  using VertexDataRange = typename DLCSR::VertexDataRange;
+  using LocalVertexRange = RefSpan<Vertex>;
+  using LocalVertexDataRange = pando::Span<VertexData>;
+
+private:
+  template <typename T>
+  pando::GlobalRef<CSR> getCSR(pando::GlobalPtr<T> ptr) {
+    return dlcsr.getCSR(ptr);
+  }
+
+  EdgeHandle halfEdgeBegin(VertexTopologyID vertex) {
+    return dlcsr.halfEdgeBegin(vertex);
+  }
+
+  EdgeHandle halfEdgeEnd(VertexTopologyID vertex) {
+    return dlcsr.halfEdgeEnd(vertex);
+  }
+
+  std::uint64_t numVHosts() {
+    return dlcsr.numVHosts();
+  }
+
+public:
+  constexpr MirrorDistLocalCSR() noexcept = default;
+  constexpr MirrorDistLocalCSR(MirrorDistLocalCSR&&) noexcept = default;
+  constexpr MirrorDistLocalCSR(const MirrorDistLocalCSR&) noexcept = default;
+  ~MirrorDistLocalCSR() = default;
+
+  constexpr MirrorDistLocalCSR& operator=(const MirrorDistLocalCSR&) noexcept = default;
+  constexpr MirrorDistLocalCSR& operator=(MirrorDistLocalCSR&&) noexcept = default;
+
+  /** Official Graph APIS **/
+  void deinitialize() {
+    dlcsr.deinitialize();
+  }
+
+  /** size stuff **/
+  std::uint64_t size() noexcept {
+    return dlcsr.size() - _mirror_size;
+  }
+  std::uint64_t size() const noexcept {
+    return dlcsr.size() - _mirror_size;
+  }
+  std::uint64_t sizeEdges() noexcept {
+    return dlcsr.sizeEdges();
+  }
+  std::uint64_t sizeEdges() const noexcept {
+    return dlcsr.sizeEdges();
+  }
+  std::uint64_t getNumEdges(VertexTopologyID vertex) {
+    return dlcsr.getNumEdges(vertex);
+  }
+  std::uint64_t sizeMirrors() noexcept {
+    return _mirror_size;
+  }
+  std::uint64_t sizeMirrors() const noexcept {
+    return _mirror_size;
+  }
+
+  /** Vertex Manipulation **/
+  VertexTopologyID getTopologyID(VertexTokenID tid) {
+    return dlcsr.getTopologyID(tid);
+  }
+
+  VertexTopologyID getTopologyIDFromIndex(std::uint64_t index) {
+    return dlcsr.getTopologyIDFromIndex(index);
+  }
+  VertexTokenID getTokenID(VertexTopologyID tid) {
+    return dlcsr.getTokenID(tid);
+  }
+  std::uint64_t getVertexIndex(VertexTopologyID vertex) {
+    return dlcsr.getVertexIndex(vertex);
+  }
+  pando::Place getLocalityVertex(VertexTopologyID vertex) {
+    return dlcsr.getLocalityVertex(vertex);
+  }
+
+  /** Edge Manipulation **/
+  EdgeHandle mintEdgeHandle(VertexTopologyID vertex, std::uint64_t off) {
+    return dlcsr.mintEdgeHandle(vertex, off);
+  }
+  VertexTopologyID getEdgeDst(EdgeHandle eh) {
+    return dlcsr.getEdgeDst(eh);
+  }
+
+  /** Data Manipulations **/
+  void setData(VertexTopologyID vertex, VertexData data) {
+    dlcsr.setData(vertex, data);
+  }
+  pando::GlobalRef<VertexData> getData(VertexTopologyID vertex) {
+    return dlcsr.getData(vertex);
+  }
+  void setEdgeData(EdgeHandle eh, EdgeData data) {
+    dlcsr.setEdgeData(eh, data);
+  }
+  pando::GlobalRef<EdgeData> getEdgeData(EdgeHandle eh) {
+    return dlcsr.getEdgeData(eh);
+  }
+
+  /** Ranges **/
+  VertexRange vertices() {
+    // This will include all mirrored vertices
+    return dlcsr.vertices();
+  }
+
+  EdgeRange edges(pando::GlobalPtr<galois::Vertex> vPtr) {
+    return dlcsr.edges(vPtr);
+  }
+  VertexDataRange vertexDataRange() noexcept {
+    return dlcsr.vertexDataRange();
+  }
+  EdgeDataRange edgeDataRange(VertexTopologyID vertex) noexcept {
+    return dlcsr.edgeDataRange(vertex);
+  }
+
+  /** Topology Modifications **/
+  VertexTopologyID addVertexTopologyOnly(VertexTokenID token) {
+    return dlcsr.addVertexTopologyOnly(token);
+  }
+  VertexTopologyID addVertex(VertexTokenID token, VertexData data) {
+    return dlcsr.addVertex(token, data);
+  }
+  pando::Status addEdgesTopologyOnly(VertexTopologyID src, pando::Vector<VertexTopologyID> dsts) {
+    return dlcsr.addEdgesTopologyOnly(src, dsts);
+  }
+  pando::Status addEdges(VertexTopologyID src, pando::Vector<VertexTopologyID> dsts,
+                         pando::Vector<EdgeData> data) {
+    return dlcsr.addEdges(src, dsts, data);
+  }
+  pando::Status deleteEdges(VertexTopologyID src, pando::Vector<EdgeHandle> edges) {
+    return dlcsr.deleteEdges(src, edges);
+  }
+
+  /** Gluon Graph APIS **/
+
+  /** Size **/
+  std::uint64_t getMasterSize() noexcept {
+    return lift(masterRange.getLocal(), size);
+  }
+  std::uint64_t getMirrorSize() noexcept {
+    return lift(mirrorRange.getLocal(), size);
+  }
+
+  /** Range **/
+  LocalVertexRange getMasterRange() {
+    return masterRange.getLocal();
+  }
+  LocalVertexRange getMirrorRange() {
+    return mirrorRange.getLocal();
+  }
+
+  /** Host Information **/
+  std::uint64_t getPhysicalHostID(VertexTokenID tid) {
+    return dlcsr.getPhysicalHostID(tid);
+  }
+
+  /** Sync **/
+  // TODO(Ying-Wei):
+  // write a sync function that reduces mirror values and then broadcasts master values
+  // return a bitmap of modified vertices
+  //
+  // template <typename Func>
+  // pando::Array<bool> sync(Func func, pando::Array<bool>) {
+  //}
+
+  /**
+   * @brief get vertex local dense ID
+   */
+  std::uint64_t getVertexLocalIndex(VertexTopologyID vertex) {
+    return dlcsr.getVertexIndex(vertex);
+  }
+
+  /**
+   * @brief gives the number of edges
+   */
+
+  std::uint64_t localSize(std::uint32_t host) noexcept {
+    return dlcsr.localSize(host);
+  }
+
+  /**
+   * @brief Sets the value of the edge provided
+   */
+  void setEdgeData(VertexTopologyID vertex, std::uint64_t off, EdgeData data) {
+    dlcsr.setEdgeData(mintEdgeHandle(vertex, off), data);
+  }
+
+  /**
+   * @brief gets the reference to the vertex provided
+   */
+  pando::GlobalRef<EdgeData> getEdgeData(VertexTopologyID vertex, std::uint64_t off) {
+    return dlcsr.getEdgeData(mintEdgeHandle(vertex, off));
+  }
+
+  /**
+   * @brief get the vertex at the end of the edge provided by vertex at the offset from the start
+   */
+  VertexTopologyID getEdgeDst(VertexTopologyID vertex, std::uint64_t off) {
+    return dlcsr.getEdgeDst(mintEdgeHandle(vertex, off));
+  }
+
+  bool isLocal(VertexTopologyID vertex) {
+    return dlcsr.isLocal(vertex);
+  }
+
+  bool isOwned(VertexTopologyID vertex) {
+    return dlcsr.isOwned(vertex);
+  }
+
+  /**
+   * @brief Get the local csr
+   */
+  pando::GlobalRef<CSR> getLocalCSR() {
+    return dlcsr.getLocalCSR();
+  }
+
+  struct MirrorToMasterMap {
+    MirrorToMasterMap() = default;
+    MirrorToMasterMap(VertexTopologyID _mirror, VertexTopologyID _master)
+        : mirror(_mirror), master(_master) {}
+    VertexTopologyID mirror;
+    VertexTopologyID master;
+    VertexTopologyID getMirror() {
+      return mirror;
+    }
+    VertexTopologyID getMaster() {
+      return master;
+    }
+  };
+
+  // TODO(Jeageun):
+  // write a initialize function that calls initializeAfterGather function of DistLocalCSR dlcsr
+  template <typename ReadVertexType, typename ReadEdgeType>
+  pando::Status initializeAfterGather(
+      galois::HostIndexedMap<pando::Vector<ReadVertexType>> vertexData, std::uint64_t numVertices,
+      galois::HostIndexedMap<pando::Vector<pando::Vector<ReadEdgeType>>> edgeData,
+      galois::HostIndexedMap<galois::HashTable<std::uint64_t, std::uint64_t>> edgeMap,
+      galois::HostIndexedMap<std::uint64_t> numEdges,
+      HostLocalStorage<pando::Array<std::uint64_t>> virtualToPhysical) {
+    std::uint64_t numHosts = static_cast<std::uint64_t>(pando::getPlaceDims().node.id);
+    galois::WaitGroup wg;
+    PANDO_CHECK(wg.initialize(numHosts));
+    auto wgh = wg.getHandle();
+    _mirror_size = 0;
+    HostLocalStorage<pando::Array<VertexTokenID>> mirrorList;
+    mirrorList = this->dlcsr.getMirrorList(edgeData, virtualToPhysical);
+
+    auto mirrorAttach = +[](galois::HostIndexedMap<pando::Vector<ReadVertexType>> vertexData,
+                            HostLocalStorage<pando::Array<VertexTokenID>> mirrorList,
+                            std::uint64_t i, galois::WaitGroup::HandleType wgh) {
+      pando::Vector<ReadVertexType> curVertexData = vertexData.get(i);
+      pando::Array<VertexTokenID> curMirrorList = mirrorList.get(i);
+      for (uint64_t j = 0; j < lift(curMirrorList, size); j++) {
+        ReadVertexType v = ReadVertexType{curMirrorList[j]};
+        PANDO_CHECK(fmap(curVertexData, pushBack, v));
+      }
+      vertexData.get(i) = curVertexData;
+      wgh.done();
+    };
+    uint64_t local_mirror_size = 0;
+    for (std::uint64_t i = 0; i < numHosts; i++) {
+      pando::Place place = pando::Place{pando::NodeIndex{static_cast<std::int16_t>(i)},
+                                        pando::anyPod, pando::anyCore};
+      PANDO_CHECK(pando::executeOn(place, mirrorAttach, vertexData, mirrorList, i, wgh));
+      local_mirror_size = lift(mirrorList.get(i), size);
+      numVertices += local_mirror_size;
+      _mirror_size += local_mirror_size;
+    }
+    PANDO_CHECK(wg.wait());
+    wgh.add(numHosts);
+
+    this->dlcsr.initializeAfterGather(vertexData, numVertices, edgeData, edgeMap, numEdges,
+                                      virtualToPhysical);
+
+    // Generate masterRange, mirrorRange, localMirrorToRemoteMasterOrderedTable
+    auto generateMetadata = +[](MirrorDistLocalCSR<VertexType, EdgeType> mdlcsr,
+                                DistLocalCSR<VertexType, EdgeType> dlcsr,
+                                HostLocalStorage<pando::Array<std::uint64_t>> mirrorList,
+                                std::uint64_t i, galois::WaitGroup::HandleType wgh) {
+      pando::Array<std::uint64_t> localMirrorList = mirrorList.get(i);
+      uint64_t mirror_size = lift(localMirrorList, size);
+      CSR csrCurr = dlcsr.arrayOfCSRs.get(i);
+
+      LocalVertexRange _masterRange = mdlcsr.masterRange.get(i);
+      _masterRange = LocalVertexRange(lift(csrCurr, vertexEdgeOffsets.begin),
+                                      lift(csrCurr, size) - 1 - mirror_size);
+
+      LocalVertexRange _mirrorRange = mdlcsr.mirrorRange.get(i);
+      _mirrorRange = LocalVertexRange(
+          lift(csrCurr, vertexEdgeOffsets.begin) + lift(csrCurr, size) - mirror_size - 1,
+          mirror_size - 1);
+
+      pando::Array<MirrorToMasterMap> _localMirrorToRemoteMasterOrderedTable =
+          mdlcsr.localMirrorToRemoteMasterOrderedTable.get(i);
+      fmap(_localMirrorToRemoteMasterOrderedTable, initialize, mirror_size);
+      for (uint64_t j = 0; j < mirror_size; j++) {
+        _localMirrorToRemoteMasterOrderedTable[j] =
+            MirrorToMasterMap(dlcsr.getLocalTopologyID(localMirrorList[j]),
+                              dlcsr.getGlobalTopologyID(localMirrorList[j]));
+        std::cout << pando::getCurrentPlace().node.id << ", " << localMirrorList[j] << " / "
+                  << uint64_t(lift(_localMirrorToRemoteMasterOrderedTable[j], getMirror).address)
+                  << ", "
+                  << uint64_t(lift(_localMirrorToRemoteMasterOrderedTable[j], getMaster).address)
+                  << std::endl;
+      }
+      wgh.done();
+    };
+
+    for (std::uint64_t i = 0; i < numHosts; i++) {
+      pando::Place place = pando::Place{pando::NodeIndex{static_cast<std::int16_t>(i)},
+                                        pando::anyPod, pando::anyCore};
+      PANDO_CHECK(
+          pando::executeOn(place, generateMetadata, *this, this->dlcsr, mirrorList, i, wgh));
+      numVertices += lift(mirrorList.get(i), size);
+    }
+    PANDO_CHECK(wg.wait());
+    return pando::Status::Success;
+  }
+
+  // TODO(Ying-Wei):
+  // uses doAll to send remoteMasterToLocalMirrorMap to corresponding remote hosts
+  // no need to use executeON
+  // just push to the localMasterToRemoteMirrorOrderedTable vector
+  // make sure to use the spin lock in pando-rt
+  /**
+   * @brief Get the local mutex
+   */
+  pando::GlobalRef<pando::Mutex> getLocalMutex(std::uint64_t host_id) {
+    return hostMutex.get(host_id);
+  }
+
+  pando::Status setupCommunication() {
+    PANDO_CHECK_RETURN(localMasterToRemoteMirrorTable.initialize());
+
+    PANDO_CHECK_RETURN(hostMutex.initialize());
+
+    PANDO_CHECK_RETURN(galois::doAll(
+        localMirrorToRemoteMasterOrderedTable, localMasterToRemoteMirrorTable,
+        +[](galois::HostLocalStorage<pando::Array<MirrorToMasterMap>>
+                localMirrorToRemoteMasterOrderedTable,
+            pando::GlobalRef<pando::Vector<EdgeHandle>> localMasterToRemoteMirrorTable) {
+          PANDO_CHECK(fmap(localMirrorToRemoteMasterOrderedTable, initialize, 0));
+          pando::Array<MirrorToMasterMap> remoteMasterToLocalMirrorMap =
+              localMirrorToRemoteMasterOrderedTable.getLocal();
+          for (MirrorToMasterMap m : remoteMasterToLocalMirrorMap) {
+            VertexTopologyID masterTopologyID = m.master;
+            VertexTokenID masterTokenID = getTokenID(masterTopologyID);
+            std::uint64_t physicalHost = getPhysicalHostID(masterTokenID);
+            pando::Mutex mutex = getLocalMutex(physicalHost);
+
+            // Lock mutex to ensure atomic append to the vector
+            mutex.lock();
+            PANDO_CHECK(fmap(localMasterToRemoteMirrorTable, pushBack, m));
+            mutex.unlock();
+          }
+        }));
+
+    return pando::Status::Success;
+  }
+
+private:
+  DLCSR dlcsr;
+  uint64_t _mirror_size;
+  galois::HostLocalStorage<LocalVertexRange> masterRange;
+  galois::HostLocalStorage<LocalVertexRange> mirrorRange;
+  galois::HostLocalStorage<pando::Array<MirrorToMasterMap>> localMirrorToRemoteMasterOrderedTable;
+
+  // TODO(Ying-Wei):
+  // generate the following
+  galois::HostLocalStorage<pando::Mutex> hostMutex;
+  galois::HostLocalStorage<pando::Vector<EdgeHandle>> localMasterToRemoteMirrorTable;
+  // galois::GlobalBarrier barrier;
+};
+
+static_assert(graph_checker<MirrorDistLocalCSR<std::uint64_t, std::uint64_t>>::value);
+static_assert(graph_checker<MirrorDistLocalCSR<WMDVertex, WMDEdge>>::value);
+
+} // namespace galois
+
+#endif // PANDO_LIB_GALOIS_GRAPHS_MIRROR_DIST_LOCAL_CSR_HPP_

--- a/include/pando-lib-galois/graphs/mirror_dist_local_csr.hpp
+++ b/include/pando-lib-galois/graphs/mirror_dist_local_csr.hpp
@@ -360,11 +360,6 @@ public:
         _localMirrorToRemoteMasterOrderedTable[j] =
             MirrorToMasterMap(dlcsr.getLocalTopologyID(localMirrorList[j]),
                               dlcsr.getGlobalTopologyID(localMirrorList[j]));
-        std::cout << pando::getCurrentPlace().node.id << ", " << localMirrorList[j] << " / "
-                  << uint64_t(lift(_localMirrorToRemoteMasterOrderedTable[j], getMirror).address)
-                  << ", "
-                  << uint64_t(lift(_localMirrorToRemoteMasterOrderedTable[j], getMaster).address)
-                  << std::endl;
       }
       wgh.done();
     };

--- a/include/pando-lib-galois/import/ingest_rmat_el.hpp
+++ b/include/pando-lib-galois/import/ingest_rmat_el.hpp
@@ -9,6 +9,7 @@
 #include <pando-lib-galois/containers/dist_array.hpp>
 #include <pando-lib-galois/containers/hashtable.hpp>
 #include <pando-lib-galois/graphs/dist_local_csr.hpp>
+#include <pando-lib-galois/graphs/mirror_dist_local_csr.hpp>
 #include <pando-rt/memory/memory_guard.hpp>
 
 namespace galois {
@@ -50,10 +51,9 @@ pando::Status generateEdgesPerVirtualHost(pando::GlobalRef<pando::Vector<ELVerte
                                           std::uint64_t totalVertices, std::uint64_t vHostID,
                                           std::uint64_t numVHosts);
 
-template <typename VertexType, typename EdgeType>
-galois::DistLocalCSR<VertexType, EdgeType> initializeELDLCSR(pando::Array<char> filename,
-                                                             std::uint64_t numVertices,
-                                                             std::uint64_t vHostsScaleFactor = 8) {
+template <typename ReturnType, typename VertexType, typename EdgeType>
+ReturnType initializeELDLCSR(pando::Array<char> filename, std::uint64_t numVertices,
+                             std::uint64_t vHostsScaleFactor = 8) {
   galois::PerThreadVector<pando::Vector<ELEdge>> localEdges;
   PANDO_CHECK(localEdges.initialize());
 
@@ -146,7 +146,7 @@ galois::DistLocalCSR<VertexType, EdgeType> initializeELDLCSR(pando::Array<char> 
   auto [partEdges, renamePerHost] =
       internal::partitionEdgesParallely(pHV, std::move(localEdges), v2PM);
 
-  using Graph = galois::DistLocalCSR<VertexType, EdgeType>;
+  using Graph = ReturnType;
   Graph graph;
   graph.template initializeAfterGather<galois::ELVertex, galois::ELEdge>(
       pHV, numVertices, partEdges, renamePerHost, numEdges,

--- a/test/graphs/CMakeLists.txt
+++ b/test/graphs/CMakeLists.txt
@@ -3,3 +3,5 @@
 
 pando_add_driver_test(test_dist_array_csr test_dist_array_csr.cpp)
 pando_add_driver_test(test_local_csr  test_local_csr.cpp)
+pando_add_driver_test(test_dist_local_csr test_dist_local_csr.cpp)
+pando_add_driver_test(test_mirror_dist_local_csr test_mirror_dist_local_csr.cpp)

--- a/test/graphs/test_mirror_dist_local_csr.cpp
+++ b/test/graphs/test_mirror_dist_local_csr.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2023. University of Texas at Austin. All rights reserved.
+
+#include <gtest/gtest.h>
+
+#include <variant>
+
+#include "pando-rt/export.h"
+#include <pando-lib-galois/containers/dist_array.hpp>
+#include <pando-lib-galois/graphs/graph_traits.hpp>
+#include <pando-lib-galois/graphs/mirror_dist_local_csr.hpp>
+#include <pando-lib-galois/loops/do_all.hpp>
+#include <pando-lib-galois/sync/wait_group.hpp>
+#include <pando-rt/containers/vector.hpp>
+#include <pando-rt/memory/memory_guard.hpp>
+#include <pando-rt/pando-rt.hpp>
+#include <pando-rt/sync/notification.hpp>
+
+pando::Vector<pando::Vector<std::uint64_t>> generateFullyConnectedGraph(std::uint64_t SIZE) {
+  pando::Vector<pando::Vector<std::uint64_t>> vec;
+  EXPECT_EQ(vec.initialize(SIZE), pando::Status::Success);
+  for (pando::GlobalRef<pando::Vector<std::uint64_t>> edges : vec) {
+    pando::Vector<std::uint64_t> inner;
+    EXPECT_EQ(inner.initialize(0), pando::Status::Success);
+    edges = inner;
+  }
+
+  galois::doAll(
+      SIZE, vec, +[](std::uint64_t size, pando::GlobalRef<pando::Vector<std::uint64_t>> innerRef) {
+        pando::Vector<std::uint64_t> inner = innerRef;
+        for (std::uint64_t i = 0; i < size; i++) {
+          EXPECT_EQ(inner.pushBack(i), pando::Status::Success);
+        }
+        innerRef = inner;
+      });
+  return vec;
+}
+
+template <typename T>
+pando::Status deleteVectorVector(pando::Vector<pando::Vector<T>> vec) {
+  auto err = galois::doAll(
+      vec, +[](pando::GlobalRef<pando::Vector<T>> innerRef) {
+        pando::Vector<std::uint64_t> inner = innerRef;
+        inner.deinitialize();
+        innerRef = inner;
+      });
+  vec.deinitialize();
+  return err;
+}
+
+using Graph = galois::MirrorDistLocalCSR<std::uint64_t, std::uint64_t>;
+
+TEST(MirrorDistLocalCSR, NumVertices) {
+  constexpr std::uint64_t SIZE = 10;
+  Graph graph;
+  auto vec = generateFullyConnectedGraph(SIZE);
+
+  EXPECT_EQ(deleteVectorVector(vec), pando::Status::Success);
+}

--- a/test/import/test_wmd_importer.cpp
+++ b/test/import/test_wmd_importer.cpp
@@ -404,7 +404,3 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple("/pando/graphs/rmat_571919_seed1_scale12_nV4096_nE48335.el", 4096),
         std::make_tuple("/pando/graphs/rmat_571919_seed1_scale13_nV8192_nE102016.el", 8192),
         std::make_tuple("/pando/graphs/rmat_571919_seed1_scale14_nV16384_nE213350.el", 16384),
-        std::make_tuple("/pando/graphs/rmat_571919_seed1_scale15_nV32768_nE441929.el", 32768),
-        std::make_tuple("/pando/graphs/rmat_571919_seed1_scale16_nV65536_nE909846.el", 65536),
-        std::make_tuple("/pando/graphs/rmat_571919_seed1_scale17_nV131072_nE1864704.el", 131072),
-        std::make_tuple("/pando/graphs/rmat_571919_seed1_scale18_nV262144_nE3806162.el", 262144)));


### PR DESCRIPTION
<!--
  ~ SPDX-License-Identifier: MIT
  ~ Copyright (c) 2023. University of Texas at Austin. All rights reserved.
  -->

# Description
MDLCSR implementation

## PR description

It may not pass the test which refers the getnumEdges. It can't actually copy edge data during mirroring. It only copy the vertex data. As a result, when it tries to get number of edges from mirrored vertex, it will look at the locally mirrored edge list, which is always 0. To fix it, we need to communicate with master, or somehow copy that data.
Currently, it doesn't contain any tests specific for this change.


## Checklist

- [ ] The additions follow the code standards in the [developer guide](pando-rt/docs/developer.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
