### PR TITLE
Sort EL before create DLCSR (need for TC)

### DIFF
--- a/test/import/test_wmd_importer.cpp
+++ b/test/import/test_wmd_importer.cpp
@@ -249,6 +249,16 @@ TEST_P(DLCSRInitEdgeList, initializeEL) {
       EXPECT_EQ(eData.src, numVertices);
       EXPECT_EQ(eData.dst, numVertices);
     }
+
+    // Check edge lists are sorted when read from RMAT
+    auto src_edges = graph.edges(vert);
+    auto end_ptr = src_edges.end();
+    end_ptr--;
+    for (auto it = src_edges.begin(); it != end_ptr && it != src_edges.end(); it++) {
+      typename Graph::VertexTopologyID dst0 = graph.getEdgeDst(*it);
+      typename Graph::VertexTopologyID dst1 = graph.getEdgeDst(*(it + 1));
+      EXPECT_LE(graph.getTokenID(dst0), graph.getTokenID(dst1));
+    }
   }
   graph.deinitialize();
 }


### PR DESCRIPTION
<!--
  ~ SPDX-License-Identifier: MIT
  ~ Copyright (c) 2023. University of Texas at Austin. All rights reserved.
  -->

# Description
Update `initializeELDLCSR` to sort edge lists when reading RMAT files and creating DistLocalCSRs.