### PR TITLE
Tests are now reliable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        build-type: ['Release', 'Sanitize']
+        build-type: ['Release', 'LSAN', 'UBSAN']
 
     steps:
 
@@ -54,9 +54,13 @@ jobs:
         echo "SRC_DIR=$(pwd)" >> $GITHUB_ENV
         echo "PANDO_TEST_DISCOVERY_TIMEOUT=600" >> $GITHUB_ENV
         echo "IMAGE_VERSION=$(git log --pretty="%h" -1 Dockerfile.dev)" >> $GITHUB_ENV
-        if [ ${{ matrix.build-type }} == 'Sanitize' ]; then
+        if [ ${{ matrix.build-type }} == 'LSAN' ]; then
           echo "PANDO_BUILD_DOCS=OFF" >> $GITHUB_ENV
-          echo "PANDO_CONTAINER_ENV=-e=PANDO_PREP_L1SP_HART=32768 -ePANDO_PREP_MAIN_NODE=8589934592" >> $GITHUB_ENV
+          echo "PANDO_CONTAINER_ENV=-e=PANDO_PREP_L1SP_HART=16384 -ePANDO_PREP_MAIN_NODE=8589934592" >> $GITHUB_ENV
+        fi
+        if [ ${{ matrix.build-type }} == 'UBSAN' ]; then
+          echo "PANDO_BUILD_DOCS=OFF" >> $GITHUB_ENV
+          echo "PANDO_CONTAINER_ENV=-e=PANDO_PREP_L1SP_HART=16384 -ePANDO_PREP_MAIN_NODE=8589934592" >> $GITHUB_ENV
         fi
         if [ ${{ matrix.build-type }} == 'Release' ]; then
           echo "PANDO_BUILD_DOCS=OFF" >> $GITHUB_ENV

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,24 +45,62 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 endif()
 
 #create the sanitize build type
-set(CMAKE_CXX_FLAGS_SANITIZE
-  "-O2 -g -fsanitize=address -fsanitize=undefined -DNDEBUG" CACHE STRING "Flags used by the C++ compiler during sanitizer builds"
+set(CMAKE_CXX_FLAGS_ASAN
+  "-O2 -fsanitize=address -DNDEBUG" CACHE STRING "Flags used by the C++ compiler during sanitizer builds"
   FORCE )
-set(CMAKE_C_FLAGS_SANITIZE
-  "-O2 -g -fsanitize=address -fsanitize=undefined -DNDEBUG" CACHE STRING "Flags used by the C compiler during sanitizer builds"
+set(CMAKE_C_FLAGS_ASAN
+  "-O2 -fsanitize=address -DNDEBUG" CACHE STRING "Flags used by the C compiler during sanitizer builds"
   FORCE )
-set(CMAKE_EXE_LINKER_FLAGS_SANITIZE
+set(CMAKE_EXE_LINKER_FLAGS_ASAN
   "" CACHE STRING "Flags used for linking binaries during sanitizer builds"
   FORCE )
-set(CMAKE_SHARED_LINKER_FLAGS_SANITIZE
+set(CMAKE_SHARED_LINKER_FLAGS_ASAN
   "" CACHE STRING "Flags used for linking shared libraries during sanitizer builds"
   FORCE )
 
 MARK_AS_ADVANCED(
-  CMAKE_CXX_FLAGS_SANITIZE
-  CMAKE_C_FLAGS_SANITIZE
-  CMAKE_EXE_LINKER_FLAGS_SANITIZE
-  CMAKE_SHARED_LINKER_FLAGS_SANITIZE)
+  CMAKE_CXX_FLAGS_ASAN
+  CMAKE_C_FLAGS_ASAN
+  CMAKE_EXE_LINKER_FLAGS_ASAN
+  CMAKE_SHARED_LINKER_FLAGS_ASAN)
+
+set(CMAKE_CXX_FLAGS_UBSAN
+  "-O2 -fsanitize=undefined -DNDEBUG" CACHE STRING "Flags used by the C++ compiler during sanitizer builds"
+  FORCE )
+set(CMAKE_C_FLAGS_UBSAN
+  "-O2 -fsanitize=undefined -DNDEBUG" CACHE STRING "Flags used by the C compiler during sanitizer builds"
+  FORCE )
+set(CMAKE_EXE_LINKER_FLAGS_UBSAN
+  "" CACHE STRING "Flags used for linking binaries during sanitizer builds"
+  FORCE )
+set(CMAKE_SHARED_LINKER_FLAGS_UBSAN
+  "" CACHE STRING "Flags used for linking shared libraries during sanitizer builds"
+  FORCE )
+
+MARK_AS_ADVANCED(
+  CMAKE_CXX_FLAGS_UBSAN
+  CMAKE_C_FLAGS_UBSAN
+  CMAKE_EXE_LINKER_FLAGS_UBSAN
+  CMAKE_SHARED_LINKER_FLAGS_UBSAN)
+
+set(CMAKE_CXX_FLAGS_LSAN
+  "-O2 -fsanitize=leak -DNDEBUG" CACHE STRING "Flags used by the C++ compiler during sanitizer builds"
+  FORCE )
+set(CMAKE_C_FLAGS_LSAN
+  "-O2 -fsanitize=leak -DNDEBUG" CACHE STRING "Flags used by the C compiler during sanitizer builds"
+  FORCE )
+set(CMAKE_EXE_LINKER_FLAGS_LSAN
+  "" CACHE STRING "Flags used for linking binaries during sanitizer builds"
+  FORCE )
+set(CMAKE_SHARED_LINKER_FLAGS_LSAN
+  "" CACHE STRING "Flags used for linking shared libraries during sanitizer builds"
+  FORCE )
+
+MARK_AS_ADVANCED(
+  CMAKE_CXX_FLAGS_LSAN
+  CMAKE_C_FLAGS_LSAN
+  CMAKE_EXE_LINKER_FLAGS_LSAN
+  CMAKE_SHARED_LINKER_FLAGS_LSAN)
 
 # default build type
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo" "Sanitize" "Coverage")

--- a/include/pando-lib-galois/loops/do_all.hpp
+++ b/include/pando-lib-galois/loops/do_all.hpp
@@ -305,8 +305,8 @@ public:
       return err;
     }
 
-    uint64_t hosts = pando::getPlaceDims().node.id;
-    uint64_t workPerHost = workItems / hosts;
+    const uint64_t hosts = pando::getPlaceDims().node.id;
+    const uint64_t workPerHost = workItems / hosts;
     galois::IotaRange range(0, workItems);
     const auto end = range.end();
 

--- a/test/utility/test_prefix_sum.cpp
+++ b/test/utility/test_prefix_sum.cpp
@@ -34,24 +34,25 @@ uint64_t scan_opV(pando::Vector<uint64_t> p, uint64_t l) {
 
 TEST(PrefixSum, Init) {
   const uint64_t elts = 100;
-  galois::DistArray<uint64_t> arr;
+  galois::Array<uint64_t> arr;
   EXPECT_EQ(arr.initialize(elts), pando::Status::Success);
-  galois::DistArray<uint64_t> prefixArr;
+  galois::Array<uint64_t> prefixArr;
   EXPECT_EQ(prefixArr.initialize(elts), pando::Status::Success);
   for (uint64_t i = 0; i < arr.size(); i++) {
     arr[i] = i;
   }
 
-  using SRC = galois::DistArray<uint64_t>;
-  using DST = galois::DistArray<uint64_t>;
+  using SRC = galois::Array<uint64_t>;
+  using DST = galois::Array<uint64_t>;
   using SRC_Val = uint64_t;
   using DST_Val = uint64_t;
 
   galois::PrefixSum<SRC, DST, SRC_Val, DST_Val, transmute<uint64_t>, scan_op<SRC_Val, DST_Val>,
-                    combiner<DST_Val>, galois::DistArray>
+                    combiner<DST_Val>, galois::Array>
       prefixSum(arr, prefixArr);
-  EXPECT_EQ(prefixSum.initialize(pando::getPlaceDims().node.id), pando::Status::Success);
-  prefixSum.computePrefixSum(elts);
+  EXPECT_EQ(prefixSum.initialize(pando::getPlaceDims().core.x * pando::getPlaceDims().core.y),
+            pando::Status::Success);
+  prefixSum.computePrefixSumPasteLocality(elts);
 
   uint64_t expected = 0;
   for (uint64_t i = 0; i < prefixArr.size(); i++) {


### PR DESCRIPTION
Disabled asan instead using leak sanitizer as it doesn't require as much from the stack, making L1SP (stack memory) more reliable.
Also split out ubsan and lsan for speed.