### PR TITLE
Fix numEdges initialization

### DIFF
--- a/src/wmd_graph_importer.cpp
+++ b/src/wmd_graph_importer.cpp
@@ -24,7 +24,7 @@ galois::internal::buildVirtualToPhysicalMapping(
   for (std::uint64_t i = 0; i < numHosts; i++) {
     intermediateSort[i] =
         galois::Pair<std::uint64_t, std::uint64_t>{static_cast<std::uint64_t>(0), i};
-    numEdges.get(0) = 0;
+    numEdges[i] = 0;
   }
 
   for (auto it = labeledVirtualCounts.rbegin(); it != labeledVirtualCounts.rend(); it++) {


### PR DESCRIPTION
<!--
  ~ SPDX-License-Identifier: MIT
  ~ Copyright (c) 2023. University of Texas at Austin. All rights reserved.
  -->

# Description

Correctly initialize all elements of `numEdges` in `galois::internal::buildVirtualToPhysicalMapping`

## Important -- Read Before Creating a Pull Request

## PR description

This PR fixes the initialization of `numEdges` to write a 0 into every key. On my machine, this was causing host 1 to have an initialized memory in some tests leading to a garbage value that would cause the allocator to panic later on.

## Checklist

- [x] The additions follow the code standards in the [developer guide](pando-rt/docs/developer.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
