### PR TITLE
Get rid of the coreState check in getTaskQueue

### DIFF
--- a/pando-rt/src/drvx/cores.cpp
+++ b/pando-rt/src/drvx/cores.cpp
@@ -37,9 +37,11 @@ constexpr auto operator+(CoreState e) noexcept {
 // Per-core (L1SP) variables
 Drvx::StaticL1SP<Cores::TaskQueue*> coreQueue;
 Drvx::StaticL1SP<std::underlying_type_t<CoreState>> coreState;
+Drvx::StaticL1SP<std::int64_t> numHartsDone;
 
 // Per-PXN (main memory) variables
-Drvx::StaticMainMem<std::int64_t> numCoresReady;
+Drvx::StaticMainMem<std::int64_t> numCoresInitialized;
+Drvx::StaticMainMem<std::int64_t> numCoresFinalized;
 
 } // namespace
 
@@ -71,18 +73,18 @@ void Cores::initializeQueues() {
 #if defined(PANDO_RT_BYPASS)
     void *addr_native = nullptr;
     std::size_t size = 0;
-    DrvAPI::DrvAPIAddressToNative(toNativeDrvPointerOnDram(numCoresReady, NodeIndex(pando::getCurrentNode().id)), &addr_native, &size);
+    DrvAPI::DrvAPIAddressToNative(toNativeDrvPointerOnDram(numCoresInitialized, NodeIndex(pando::getCurrentNode().id)), &addr_native, &size);
     std::int64_t* as_native_pointer = reinterpret_cast<std::int64_t*>(addr_native);
     __atomic_fetch_add(as_native_pointer, 1u, static_cast<int>(std::memory_order_relaxed));
     // hartYield
     DrvAPI::nop(1u);
 #else
-    DrvAPI::atomic_add(toNativeDrvPointerOnDram(numCoresReady, NodeIndex(pando::getCurrentNode().id)), 1u);
+    DrvAPI::atomic_add(toNativeDrvPointerOnDram(numCoresInitialized, NodeIndex(pando::getCurrentNode().id)), 1u);
 #endif
   }
 
   // Other harts just wait until state is ready
-  while (coreState != +CoreState::Ready) {
+  while (DrvAPI::read<std::int8_t>(&coreState) != +CoreState::Ready) {
     hartYield();
   }
 }
@@ -90,6 +92,8 @@ void Cores::initializeQueues() {
 void Cores::finalizeQueues() {
   // One hart per core does all the finalization. Use CAS to choose some/any hart for this
   // purpose.
+  signalHartDone();
+
 #if defined(PANDO_RT_BYPASS)
   void *addr_native = nullptr;
   std::size_t size = 0;
@@ -105,6 +109,14 @@ void Cores::finalizeQueues() {
 #else
   if (DrvAPI::atomic_cas(&coreState, +CoreState::Ready, +CoreState::Idle) == +CoreState::Ready) {
 #endif
+    // wait for all harts on this core to be done
+    waitForHartsDone();
+
+    signalCoreFinalized();
+
+    // wait for all cores on this PXN to be finalized
+    waitForCoresFinalized();
+
     DrvAPI::write(&coreState, +CoreState::Stopped);
 
     TaskQueue* queue = coreQueue;
@@ -126,12 +138,51 @@ bool Cores::CoreActiveFlag::operator*() const noexcept {
 }
 
 Cores::TaskQueue* Cores::getTaskQueue(Place place) noexcept {
-  if(*toNativeDrvPtr(coreState, place) != +CoreState::Ready) return nullptr;
   return *toNativeDrvPtr(coreQueue, place);
 }
 
-void Cores::waitForCoresInit() {
-  while (*toNativeDrvPointerOnDram(numCoresReady, NodeIndex(pando::getCurrentNode().id)) != Drvx::getCoreDims().x) {
+void Cores::waitForCoresInitialized() {
+  while (*toNativeDrvPointerOnDram(numCoresInitialized, NodeIndex(pando::getCurrentNode().id)) != Drvx::getCoreDims().x) {
+    hartYield();
+  }
+}
+
+void Cores::signalHartDone() {
+#if defined(PANDO_RT_BYPASS)
+  void *addr_native = nullptr;
+  std::size_t size = 0;
+  DrvAPI::DrvAPIAddressToNative(toNativeDrvPtr(numHartsDone, getCurrentPlace()), &addr_native, &size);
+  std::int64_t* as_native_pointer = reinterpret_cast<std::int64_t*>(addr_native);
+  __atomic_fetch_add(as_native_pointer, 1u, static_cast<int>(std::memory_order_relaxed));
+  // hartYield
+  DrvAPI::nop(1u);
+#else
+  DrvAPI::atomic_add(toNativeDrvPtr(numHartsDone, getCurrentPlace()), 1u);
+#endif
+}
+
+void Cores::waitForHartsDone() {
+  while (DrvAPI::read<std::int64_t>(toNativeDrvPtr(numHartsDone, getCurrentPlace())) != Drvx::getThreadDims().id) {
+    hartYield();
+  }
+}
+
+void Cores::signalCoreFinalized() {
+#if defined(PANDO_RT_BYPASS)
+  void *addr_native = nullptr;
+  std::size_t size = 0;
+  DrvAPI::DrvAPIAddressToNative(toNativeDrvPointerOnDram(numCoresFinalized, NodeIndex(pando::getCurrentNode().id)), &addr_native, &size);
+  std::int64_t* as_native_pointer = reinterpret_cast<std::int64_t*>(addr_native);
+  __atomic_fetch_add(as_native_pointer, 1u, static_cast<int>(std::memory_order_relaxed));
+  // hartYield
+  DrvAPI::nop(1u);
+#else
+  DrvAPI::atomic_add(toNativeDrvPointerOnDram(numCoresFinalized, NodeIndex(pando::getCurrentNode().id)), 1u);
+#endif
+}
+
+void Cores::waitForCoresFinalized() {
+  while (*toNativeDrvPointerOnDram(numCoresFinalized, NodeIndex(pando::getCurrentNode().id)) != Drvx::getCoreDims().x) {
     hartYield();
   }
 }

--- a/pando-rt/src/drvx/cores.cpp
+++ b/pando-rt/src/drvx/cores.cpp
@@ -65,7 +65,7 @@ void Cores::initializeQueues() {
     coreQueue = new TaskQueue;
 
     // indicate that core initialization is complete and state is ready
-    coreState = +CoreState::Ready;
+    DrvAPI::write(&coreState, +CoreState::Ready);
 
     // CP waits for this variable to equal total number of cores in the PXN
 #if defined(PANDO_RT_BYPASS)
@@ -105,7 +105,7 @@ void Cores::finalizeQueues() {
 #else
   if (DrvAPI::atomic_cas(&coreState, +CoreState::Ready, +CoreState::Idle) == +CoreState::Ready) {
 #endif
-    coreState = +CoreState::Stopped;
+    DrvAPI::write(&coreState, +CoreState::Stopped);
 
     TaskQueue* queue = coreQueue;
     delete queue;

--- a/pando-rt/src/drvx/cores.cpp
+++ b/pando-rt/src/drvx/cores.cpp
@@ -92,7 +92,7 @@ void Cores::initializeQueues() {
 void Cores::finalizeQueues() {
   // One hart per core does all the finalization. Use CAS to choose some/any hart for this
   // purpose.
-  signalHartDone();
+  Cores::signalHartDone();
 
 #if defined(PANDO_RT_BYPASS)
   void *addr_native = nullptr;
@@ -110,12 +110,12 @@ void Cores::finalizeQueues() {
   if (DrvAPI::atomic_cas(&coreState, +CoreState::Ready, +CoreState::Idle) == +CoreState::Ready) {
 #endif
     // wait for all harts on this core to be done
-    waitForHartsDone();
+    Cores::waitForHartsDone();
 
-    signalCoreFinalized();
+    Cores::signalCoreFinalized();
 
     // wait for all cores on this PXN to be finalized
-    waitForCoresFinalized();
+    Cores::waitForCoresFinalized();
 
     DrvAPI::write(&coreState, +CoreState::Stopped);
 

--- a/pando-rt/src/drvx/cores.hpp
+++ b/pando-rt/src/drvx/cores.hpp
@@ -51,6 +51,17 @@ public:
   static void waitForCoresInitialized();
 
   /**
+   * @brief Returns the queue associated with place @p place.
+   */
+  [[nodiscard]] static TaskQueue* getTaskQueue(Place place) noexcept;
+
+  /**
+   * @brief Returns a flag to check if the core is active.
+   */
+  static CoreActiveFlag getCoreActiveFlag() noexcept;
+
+private:
+  /**
    * @brief Signal that this hart is done.
    */
   static void signalHartDone();
@@ -69,16 +80,6 @@ public:
    * @brief Wait for all cores to be finalized.
    */
   static void waitForCoresFinalized();
-
-  /**
-   * @brief Returns the queue associated with place @p place.
-   */
-  [[nodiscard]] static TaskQueue* getTaskQueue(Place place) noexcept;
-
-  /**
-   * @brief Returns a flag to check if the core is active.
-   */
-  static CoreActiveFlag getCoreActiveFlag() noexcept;
 };
 
 } // namespace pando

--- a/pando-rt/src/drvx/cores.hpp
+++ b/pando-rt/src/drvx/cores.hpp
@@ -46,9 +46,29 @@ public:
   static void finalize();
 
   /**
-   * @brief Waits for all cores.
+   * @brief Waits for all cores to be initialized.
    */
-  static void waitForCoresInit();
+  static void waitForCoresInitialized();
+
+  /**
+   * @brief Signal that this hart is done.
+   */
+  static void signalHartDone();
+
+  /**
+   * @brief Wait for all harts on this core to be done.
+   */
+  static void waitForHartsDone();
+
+  /**
+   * @brief Signal that this core is finalized.
+   */
+  static void signalCoreFinalized();
+
+  /**
+   * @brief Wait for all cores to be finalized.
+   */
+  static void waitForCoresFinalized();
 
   /**
    * @brief Returns the queue associated with place @p place.

--- a/pando-rt/src/drvx/cp.cpp
+++ b/pando-rt/src/drvx/cp.cpp
@@ -26,7 +26,7 @@ Drvx::StaticMainMem<std::int64_t> numPxnsDone;
 // Initialize logger and memory resources
 [[nodiscard]] Status CommandProcessor::initialize() {
   // wait until all cores have initialized
-  Cores::waitForCoresInit();
+  Cores::waitForCoresInitialized();
 
   // wait for all CP to finish initialization
   barrier();
@@ -106,7 +106,7 @@ void CommandProcessor::signalCommandProcessorDone() {
 #endif
 }
 
-void CommandProcessor::waitForCommandProcessorDone() {
+void CommandProcessor::waitForCommandProcessorsDone() {
   while (*toNativeDrvPointerOnDram(numPxnsDone, NodeIndex(0)) != Drvx::getNodeDims().id) {
     hartYield();
   }
@@ -116,7 +116,7 @@ void CommandProcessor::finalize() {
   CommandProcessor::signalCommandProcessorDone();
 
   // wait for all CP to finish
-  CommandProcessor::waitForCommandProcessorDone();
+  CommandProcessor::waitForCommandProcessorsDone();
 
   // set termination flag
   setTerminateFlag();

--- a/pando-rt/src/drvx/cp.hpp
+++ b/pando-rt/src/drvx/cp.hpp
@@ -49,7 +49,17 @@ private:
   /**
    * @brief Wait for all command processors on all PXNs to be done.
    */
-  static void waitForCommandProcessorDone();
+  static void waitForCommandProcessorsDone();
+
+  /**
+   * @brief Barrier for all CPs.
+   */
+  static void barrier();
+
+  /**
+   * @brief Finalizes the CP.
+   */
+  static void finalize();
 };
 
 } // namespace pando

--- a/pando-rt/src/drvx/cp.hpp
+++ b/pando-rt/src/drvx/cp.hpp
@@ -50,16 +50,6 @@ private:
    * @brief Wait for all command processors on all PXNs to be done.
    */
   static void waitForCommandProcessorsDone();
-
-  /**
-   * @brief Barrier for all CPs.
-   */
-  static void barrier();
-
-  /**
-   * @brief Finalizes the CP.
-   */
-  static void finalize();
 };
 
 } // namespace pando


### PR DESCRIPTION
<!--
  ~ SPDX-License-Identifier: MIT
  ~ Copyright (c) 2023. University of Texas at Austin. All rights reserved.
  -->

# Description

## Important -- Read Before Creating a Pull Request

## PR description

Get rid of the DrvAPI::read in getTaskQueue to check whether the core of the task queue is ready or already stopped.
The only situation where you will get the task queue of a stopped core is when the core has entered finalizeQueue() function an deleted its task queue while the other core is still trying to do work stealing. I added some synchronization barriers to guarantee that all harts of all cores on this PXN has entered the finalizeQueue() function before deleting the task queue and there will be no more work stealing attempt.

## Checklist

- [v] The additions follow the code standards in the [developer guide](pando-rt/docs/developer.md).
- [v] New or existing tests cover these changes.
- [v] The documentation is up to date with these changes.
