### PR TITLE
assign and bind to deal with different const of functions

### DIFF
--- a/include/pando-lib-galois/graphs/dist_local_csr.hpp
+++ b/include/pando-lib-galois/graphs/dist_local_csr.hpp
@@ -329,7 +329,9 @@ public:
 
 private:
   constexpr static pando::GlobalRef<CSR> getCachedCSR(CSRCache cache, std::uint64_t i) {
-    return fmap(cache.getLocalRef(), operator[], i);
+    return applyFunc(cache.getLocalRef(), [i](HostIndexedMap<CSR> map) {
+      return map[i];
+    });
   }
 
   template <typename T>
@@ -500,9 +502,18 @@ public:
   }
 
   VertexDataRange vertexDataRange() noexcept {
-    return VertexDataRange{arrayOfCSRs, lift(getCSR(0), vertexData.begin),
-                           lift(getCSR(arrayOfCSRs.size() - 1), vertexData.end), numVertices};
+    return VertexDataRange{arrayOfCSRs,
+                           applyFunc(getCSR(0),
+                                     [](CSR csr) {
+                                       return csr.vertexData.begin();
+                                     }),
+                           applyFunc(getCSR(arrayOfCSRs.size() - 1),
+                                     [](CSR csr) {
+                                       return csr.vertexData.end();
+                                     }),
+                           numVertices};
   }
+
   EdgeDataRange edgeDataRange(VertexTopologyID vertex) noexcept {
     return fmap(getCSR(vertex), edgeDataRange, vertex);
   }

--- a/include/pando-lib-galois/utility/gptr_monad.hpp
+++ b/include/pando-lib-galois/utility/gptr_monad.hpp
@@ -54,4 +54,20 @@
     *ptrComputed##__LINE__ = tmp;                                                     \
   } while (0)
 
+#include <pando-rt/memory/global_ptr.hpp>
+
+template <typename T, typename F>
+auto bindFunc(pando::GlobalRef<T> ref, F func) {
+  T obj = ref;
+  auto ret = func(obj);
+  ref = obj;
+  return ret;
+}
+
+template <typename T, typename F>
+auto applyFunc(pando::GlobalRef<T> ref, F func) {
+  T obj = ref;
+  return func(obj);
+}
+
 #endif // PANDO_LIB_GALOIS_UTILITY_GPTR_MONAD_HPP_


### PR DESCRIPTION
assign is used when the function is const wrt to the first level of the referenced object.
bind is it's counterpart.

Both should only be used in very isolated cases.
