### PR TITLE
Make hartYield() flexible

### DIFF
--- a/pando-rt/src/atomic.cpp
+++ b/pando-rt/src/atomic.cpp
@@ -259,8 +259,7 @@ bool atomicCompareExchangeImpl(GlobalPtr<T> ptr, T& expected, const T desired,
     DrvAPI::DrvAPIAddressToNative(ptr.address, &addr_native, &size);
     T* as_native_pointer = reinterpret_cast<T*>(addr_native);
     auto result = __atomic_compare_exchange_n(as_native_pointer, &expected, desired, false, static_cast<int>(std::memory_order_relaxed), static_cast<int>(std::memory_order_relaxed));
-    // hartYield
-    DrvAPI::nop(1u);
+    hartYield(1);
 
     return result;
   } else {
@@ -356,8 +355,7 @@ void atomicIncrementImpl(GlobalPtr<T> ptr, T value, [[maybe_unused]] std::memory
     DrvAPI::DrvAPIAddressToNative(ptr.address, &addr_native, &size);
     T* as_native_pointer = reinterpret_cast<T*>(addr_native);
     __atomic_fetch_add(as_native_pointer, value, static_cast<int>(std::memory_order_relaxed));
-    // hartYield
-    DrvAPI::nop(1u);
+    hartYield(1);
   } else {
     DrvAPI::atomic_add(ptr.address, value);
   }
@@ -427,8 +425,7 @@ void atomicDecrementImpl(GlobalPtr<T> ptr, T value, [[maybe_unused]] std::memory
     DrvAPI::DrvAPIAddressToNative(ptr.address, &addr_native, &size);
     T* as_native_pointer = reinterpret_cast<T*>(addr_native);
     __atomic_fetch_add(as_native_pointer, static_cast<T>(-1) * value, static_cast<int>(std::memory_order_relaxed));
-    // hartYield
-    DrvAPI::nop(1u);
+    hartYield(1);
   } else {
     DrvAPI::atomic_add(ptr.address, static_cast<T>(-1) * value);
   }
@@ -501,8 +498,7 @@ T atomicFetchAddImpl(GlobalPtr<T> ptr, T value, [[maybe_unused]] std::memory_ord
     DrvAPI::DrvAPIAddressToNative(ptr.address, &addr_native, &size);
     T* as_native_pointer = reinterpret_cast<T*>(addr_native);
     auto result = __atomic_fetch_add(as_native_pointer, value, static_cast<int>(std::memory_order_relaxed));
-    // hartYield
-    DrvAPI::nop(1u);
+    hartYield(1);
     return result;
   } else {
     return DrvAPI::atomic_add(ptr.address, value);
@@ -577,8 +573,7 @@ T atomicFetchSubImpl(GlobalPtr<T> ptr, T value, [[maybe_unused]] std::memory_ord
     DrvAPI::DrvAPIAddressToNative(ptr.address, &addr_native, &size);
     T* as_native_pointer = reinterpret_cast<T*>(addr_native);
     auto result = __atomic_fetch_add(as_native_pointer, static_cast<T>(-1) * value, static_cast<int>(std::memory_order_relaxed));
-    // hartYield
-    DrvAPI::nop(1u);
+    hartYield(1);
     return result;
   } else {
     return DrvAPI::atomic_add(ptr.address, static_cast<T>(-1) * value);

--- a/pando-rt/src/drvx/cores.cpp
+++ b/pando-rt/src/drvx/cores.cpp
@@ -54,7 +54,7 @@ void Cores::initializeQueues() {
 
   // Other harts just wait until state is ready
   while (DrvAPI::getCoreState(Drvx::getCurrentNode().id, Drvx::getCurrentPod().x, Drvx::getCurrentCore().x) != +CoreState::Ready) {
-    hartYield();
+    hartYield(1000);
   }
 }
 
@@ -66,14 +66,14 @@ void Cores::finalizeQueues() {
   if (DrvAPI::atomicCompareExchangeCoreState(Drvx::getCurrentNode().id, Drvx::getCurrentPod().x, Drvx::getCurrentCore().x, +CoreState::Ready, +CoreState::Idle) == +CoreState::Ready) {
     // wait for all harts on this core to be done
     while (DrvAPI::getCoreHartsDone(Drvx::getCurrentNode().id, Drvx::getCurrentPod().x, Drvx::getCurrentCore().x) != Drvx::getThreadDims().id) {
-      hartYield();
+      hartYield(1000);
     }
 
     DrvAPI::atomicIncrementPodCoresFinalized(Drvx::getCurrentNode().id, Drvx::getCurrentPod().x, 1);
 
     // wait for all cores on this pod to be finalized to ensure no work stealing before deleting the queue
     while (DrvAPI::getPodCoresFinalized(Drvx::getCurrentNode().id, Drvx::getCurrentPod().x) != Drvx::getCoreDims().x) {
-      hartYield();
+      hartYield(1000);
     }
 
     DrvAPI::setCoreState(Drvx::getCurrentNode().id, Drvx::getCurrentPod().x, Drvx::getCurrentCore().x, +CoreState::Stopped);
@@ -91,7 +91,7 @@ Cores::CoreActiveFlag Cores::getCoreActiveFlag() noexcept {
 
 bool Cores::CoreActiveFlag::operator*() const noexcept {
   do {
-    hartYield();
+    hartYield(1000);
   } while ((DrvAPI::getGlobalCpsFinalized() != Drvx::getNodeDims().id) && (DrvAPI::getPodTasksRemaining(Drvx::getCurrentNode().id, Drvx::getCurrentPod().x) == 0));
 
   if (DrvAPI::getGlobalCpsFinalized() != Drvx::getNodeDims().id) {

--- a/pando-rt/src/drvx/cp.cpp
+++ b/pando-rt/src/drvx/cp.cpp
@@ -20,7 +20,7 @@ namespace {
 [[nodiscard]] Status CommandProcessor::initialize() {
   // wait until all cores have initialized
   while (DrvAPI::getPxnCoresInitialized(Drvx::getCurrentNode().id) != Drvx::getNumPxnCores()) {
-    hartYield();
+    hartYield(1000);
   }
 
 
@@ -48,7 +48,7 @@ void CommandProcessor::barrier() {
       // other PXNs are yet to reach the barrier; wait for the last PXN to reach the barrier to
       // notify this PXN.
       while (!DrvAPI::testPxnBarrierExit(Drvx::getCurrentNode().id)) {
-        hartYield();
+        hartYield(1000);
       }
     }
     SPDLOG_INFO("Barrier completed on PXN {}", Drvx::getCurrentNode());

--- a/pando-rt/src/drvx/drvx.cpp
+++ b/pando-rt/src/drvx/drvx.cpp
@@ -7,8 +7,8 @@
 namespace pando {
 
 // Yields to the next hart
-void hartYield() noexcept {
-  DrvAPI::nop(1000u);
+void hartYield(int cycle) noexcept {
+  DrvAPI::nop(cycle);
 }
 
 std::int64_t Drvx::getNumSystemCores() noexcept {

--- a/pando-rt/src/drvx/drvx.hpp
+++ b/pando-rt/src/drvx/drvx.hpp
@@ -62,7 +62,7 @@ DrvAPI::DrvAPIPointer<T> toNativeDrvPointerOnDram(const U& globalDrvObj, NodeInd
  *
  * @ingroup DRVX
  */
-void hartYield() noexcept;
+void hartYield(int cycle = 1000) noexcept;
 
 /**
  * @brief DRVX utility class with helper types and functions to query the system configuration.

--- a/pando-rt/src/global_ptr.cpp
+++ b/pando-rt/src/global_ptr.cpp
@@ -172,8 +172,7 @@ void load(GlobalAddress srcGlobalAddr, std::size_t n, void* dstNativePtr) {
       DrvAPI::DrvAPIAddressToNative(blockSrc + bytesOffset, &addr_native, &size);
       BlockType* as_native_pointer = reinterpret_cast<BlockType*>(addr_native);
       *(blockDst + i) = *as_native_pointer;
-      // hartYield
-      DrvAPI::nop(1u);
+      hartYield(1);
     }
 
     for (std::size_t i = 0; i < remainderBytes; i++) {
@@ -182,8 +181,7 @@ void load(GlobalAddress srcGlobalAddr, std::size_t n, void* dstNativePtr) {
       DrvAPI::DrvAPIAddressToNative(byteSrc + i, &addr_native, &size);
       std::byte* as_native_pointer = reinterpret_cast<std::byte*>(addr_native);
       *(byteDst + i) = *as_native_pointer;
-      // hartYield
-      DrvAPI::nop(1u);
+      hartYield(1);
     }
   } else {
     for (std::size_t i = 0; i < numBlocks; i++) {
@@ -312,8 +310,7 @@ void store(GlobalAddress dstGlobalAddr, std::size_t n, const void* srcNativePtr)
       DrvAPI::DrvAPIAddressToNative(blockDst + offset, &addr_native, &size);
       BlockType* as_native_pointer = reinterpret_cast<BlockType*>(addr_native);
       *as_native_pointer = blockData;
-      // hartYield
-      DrvAPI::nop(1u);
+      hartYield(1);
     }
 
     for (std::size_t i = 0; i < remainderBytes; i++) {
@@ -324,8 +321,7 @@ void store(GlobalAddress dstGlobalAddr, std::size_t n, const void* srcNativePtr)
       DrvAPI::DrvAPIAddressToNative(byteDst + i, &addr_native, &size);
       std::byte* as_native_pointer = reinterpret_cast<std::byte*>(addr_native);
       *as_native_pointer = byteData;
-      // hartYield
-      DrvAPI::nop(1u);
+      hartYield(1);
     }
   } else {
     for (std::size_t i = 0; i < numBlocks; i++) {

--- a/pando-rt/src/wait.cpp
+++ b/pando-rt/src/wait.cpp
@@ -35,7 +35,7 @@ void waitUntil(const Function<bool()>& f) {
   // DrvX CP is not modeled as a separate thread, so all cores (CP and PH cores) yield while busy
   // waiting.
   do {
-    hartYield();
+    hartYield(1000);
   } while (f() == false);
 
 #else
@@ -92,7 +92,7 @@ void waitAll() {
   for (std::int64_t i = 0; i < Drvx::getNodeDims().id; i++) {
     for (std::int64_t j = 0; j < Drvx::getPodDims().x; j++) {
       while (DrvAPI::getPodTasksRemaining(i, j) != 0) {
-        hartYield();
+        hartYield(1000);
       }
     }
   }


### PR DESCRIPTION
<!--
  ~ SPDX-License-Identifier: MIT
  ~ Copyright (c) 2023. University of Texas at Austin. All rights reserved.
  -->

# Description

## Important -- Read Before Creating a Pull Request

## PR description

Some hartYield can return after 1 cycle and some needs to check back every 1000 cycles. Make the number of nop cycles an argument of the function, so we don't have to call DrvAPI::nop(1) explicitly for yielding.

## Checklist

- [v] The additions follow the code standards in the [developer guide](pando-rt/docs/developer.md).
- [v] New or existing tests cover these changes.
- [v] The documentation is up to date with these changes.
