### PR TITLE
Fix to guarantee Bypass mode is more accurate

### DIFF
--- a/pando-drv/api/DrvAPIInfo.hpp
+++ b/pando-drv/api/DrvAPIInfo.hpp
@@ -279,6 +279,16 @@ inline int64_t getCoreHartsDone(int64_t pxn_id, int8_t pod_id, int8_t core_id) {
     return DrvAPISysConfig::Get()->getCoreHartsDone(pxn_id, pod_id, core_id);
 }
 
+inline void clearGlobalBypassFlag() {
+    return DrvAPISysConfig::Get()->clearGlobalBypassFlag();
+}
+inline void setGlobalBypassFlag() {
+    return DrvAPISysConfig::Get()->setGlobalBypassFlag();
+}
+inline bool getGlobalBypassFlag() {
+    return DrvAPISysConfig::Get()->getGlobalBypassFlag();
+}
+
 
 } // namespace DrvAPI
 #endif

--- a/pando-rt/include/pando-rt/drv_info.hpp
+++ b/pando-rt/include/pando-rt/drv_info.hpp
@@ -5,8 +5,6 @@
 #define PANDO_RT_DRV_INFO_HPP_
 
 #ifdef PANDO_RT_USE_BACKEND_DRVX
-#include "DrvAPIMemory.hpp"
-#include "DrvAPIThread.hpp"
 
 namespace DrvAPI {
 void setStageInit();
@@ -23,7 +21,6 @@ bool isStageInit();
 #define PANDO_DRV_SET_STAGE_OTHER() {DrvAPI::setStageOther();}
 #define PANDO_DRV_INCREMENT_PHASE() {DrvAPI::incrementPhase();}
 
-extern bool bypass_flag;
 void setBypassFlag();
 void clearBypassFlag();
 bool getBypassFlag();

--- a/pando-rt/include/pando-rt/sync/wait.hpp
+++ b/pando-rt/include/pando-rt/sync/wait.hpp
@@ -83,8 +83,17 @@ void monitorUntilNot(GlobalPtr<T> ptr, T value) {
 #endif
 }
 
+#ifdef PANDO_RT_USE_BACKEND_DRVX
 /**
- * @brief Waits for all tasks to finish executing.
+ * @brief A specific node waits for all tasks to finish executing.
+ *
+ * @ingroup ROOT
+ */
+PANDO_RT_EXPORT void waitAllTasks();
+#endif
+
+/**
+ * @brief All nodes wait for all tasks to finish executing.
  *
  * @note This is a collective operation and needs to be called by all nodes.
  *

--- a/pando-rt/src/drv_info.cpp
+++ b/pando-rt/src/drv_info.cpp
@@ -4,6 +4,7 @@
 #ifdef PANDO_RT_USE_BACKEND_DRVX
 #include "pando-rt/drv_info.hpp"
 #include <pando-rt/pando-rt.hpp>
+#include "drvx/drvx.hpp"
 
 namespace DrvAPI {
 
@@ -138,13 +139,13 @@ void incrementPhase() {
 bool bypass_flag = false;
 void setBypassFlag() {
   pando::waitAllTasks();
-  bypass_flag = true;
+  DrvAPI::setGlobalBypassFlag();
 }
 void clearBypassFlag() {
   pando::waitAllTasks();
-  bypass_flag = false;
+  DrvAPI::clearGlobalBypassFlag();
 }
 bool getBypassFlag() {
-  return bypass_flag;
+  return DrvAPI::getGlobalBypassFlag();
 }
 #endif // PANDO_RT_USE_BACKEND_DRVX

--- a/pando-rt/src/drv_info.cpp
+++ b/pando-rt/src/drv_info.cpp
@@ -137,9 +137,11 @@ void incrementPhase() {
 
 bool bypass_flag = false;
 void setBypassFlag() {
+  pando::waitAllTasks();
   bypass_flag = true;
 }
 void clearBypassFlag() {
+  pando::waitAllTasks();
   bypass_flag = false;
 }
 bool getBypassFlag() {


### PR DESCRIPTION
<!--
  ~ SPDX-License-Identifier: MIT
  ~ Copyright (c) 2023. University of Texas at Austin. All rights reserved.
  -->

# Description

## Important -- Read Before Creating a Pull Request

## PR description

Move the bypass flag to DrvAPISysControlVariable to guarantee it is global. Add barriers before we set and clear the bypass flags to make sure exactly all accesses within the bypass phase are bypassed.

## Checklist

- [ ] The additions follow the code standards in the [developer guide](pando-rt/docs/developer.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
