### PR TITLE
Work stealing switch

### DIFF
--- a/pando-rt/cmake/PANDOCompilerOptions.cmake
+++ b/pando-rt/cmake/PANDOCompilerOptions.cmake
@@ -9,6 +9,7 @@ set_property(CACHE PANDO_RT_ENABLE_MEM_TRACE PROPERTY STRINGS "OFF" "INTER-PXN" 
 option(PANDO_RT_ENABLE_MEM_STAT "Enable reporting memory access count statistics." OFF)
 option(PANDO_RT_DRVX_ENABLE_DMA "Enable reporting memory access count statistics." ON)
 option(PANDO_RT_DRVX_ENABLE_BYPASS "Enable bypassing SST simulation in DrvX." ON)
+option(PANDO_RT_ENABLE_WORK_STEALING "Enable work stealing for cores." ON)
 
 
 # Default compiler options for targets

--- a/pando-rt/cmake/PANDOCompilerOptions.cmake
+++ b/pando-rt/cmake/PANDOCompilerOptions.cmake
@@ -9,7 +9,7 @@ set_property(CACHE PANDO_RT_ENABLE_MEM_TRACE PROPERTY STRINGS "OFF" "INTER-PXN" 
 option(PANDO_RT_ENABLE_MEM_STAT "Enable reporting memory access count statistics." OFF)
 option(PANDO_RT_DRVX_ENABLE_DMA "Enable reporting memory access count statistics." ON)
 option(PANDO_RT_DRVX_ENABLE_BYPASS "Enable bypassing SST simulation in DrvX." ON)
-option(PANDO_RT_ENABLE_WORK_STEALING "Enable work stealing for cores." ON)
+option(PANDO_RT_DRVX_ENABLE_WORK_STEALING "Enable work stealing for cores." OFF)
 
 
 # Default compiler options for targets

--- a/pando-rt/src/drvx/CMakeLists.txt
+++ b/pando-rt/src/drvx/CMakeLists.txt
@@ -69,10 +69,10 @@ if(PANDO_RT_DRVX_ENABLE_BYPASS STREQUAL "ON")
     )
 endif()
 
-if(PANDO_RT_ENABLE_WORK_STEALING STREQUAL "ON")
+if(PANDO_RT_DRVX_ENABLE_WORK_STEALING STREQUAL "ON")
     target_compile_definitions(pando-rt-drvx
             PUBLIC
-                "-DPANDO_RT_WORK_STEALING=1"
+                "-DPANDO_RT_DRVX_WORK_STEALING=1"
     )
 endif()
 

--- a/pando-rt/src/drvx/CMakeLists.txt
+++ b/pando-rt/src/drvx/CMakeLists.txt
@@ -69,6 +69,13 @@ if(PANDO_RT_DRVX_ENABLE_BYPASS STREQUAL "ON")
     )
 endif()
 
+if(PANDO_RT_ENABLE_WORK_STEALING STREQUAL "ON")
+    target_compile_definitions(pando-rt-drvx
+            PUBLIC
+                "-DPANDO_RT_WORK_STEALING=1"
+    )
+endif()
+
 
 target_link_libraries(pando-rt-drvx
     PUBLIC

--- a/pando-rt/src/drvx/cores.cpp
+++ b/pando-rt/src/drvx/cores.cpp
@@ -108,4 +108,17 @@ Cores::TaskQueue* Cores::getTaskQueue(Place place) noexcept {
 void Cores::finalize() {
 }
 
+void Cores::workStealing(std::optional<pando::Task>& task) {
+  const auto thisPlace = getCurrentPlace();
+  const auto coreDims = getCoreDims();
+
+  // onyl steal from the neighbor core
+  for(std::int8_t i = thisPlace.core.x + 1; i < thisPlace.core.x + 2; i++) {
+    auto* otherQueue =  pando::Cores::getTaskQueue(pando::Place{thisPlace.node, thisPlace.pod, pando::CoreIndex(i % coreDims.x, 0)});
+    if(otherQueue->getApproxSize() > STEAL_THRESH_HOLD_SIZE) {
+      task = otherQueue->tryDequeue();
+    }
+  }
+}
+
 } // namespace pando

--- a/pando-rt/src/drvx/cores.hpp
+++ b/pando-rt/src/drvx/cores.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <tuple>
 
+#include "../start.hpp"
 #include "../queue.hpp"
 #include "pando-rt/execution/task.hpp"
 #include "pando-rt/index.hpp"
@@ -54,6 +55,11 @@ public:
    * @brief Returns a flag to check if the core is active.
    */
   static CoreActiveFlag getCoreActiveFlag() noexcept;
+
+  /**
+   * @brief Steals work from other cores.
+   */
+  static void workStealing(std::optional<pando::Task>& task);
 };
 
 } // namespace pando

--- a/pando-rt/src/prep/cores.hpp
+++ b/pando-rt/src/prep/cores.hpp
@@ -7,10 +7,12 @@
 #include <cstddef>
 #include <tuple>
 
+#include "../start.hpp"
 #include "../queue.hpp"
 #include "pando-rt/execution/task.hpp"
 #include "pando-rt/index.hpp"
 #include "pando-rt/status.hpp"
+#include <pando-rt/benchmark/counters.hpp>
 
 namespace pando {
 
@@ -120,6 +122,11 @@ public:
    * @brief Returns a flag to check if the core is active.
    */
   static CoreActiveFlag getCoreActiveFlag() noexcept;
+
+  /**
+   * @brief Steals work from other cores.
+   */
+  static void workStealing(std::optional<pando::Task>& task, SchedulerFailState& failState, counter::Record<std::int64_t>& idleCount, counter::HighResolutionCount<IDLE_TIMER_ENABLE>& idleTimer);
 };
 
 } // namespace pando

--- a/pando-rt/src/start.cpp
+++ b/pando-rt/src/start.cpp
@@ -53,6 +53,9 @@ extern "C" int __start(int argc, char** argv) {
 
     do {
       idleTimer.start();
+      // for simulation accuracy purposes
+      // getTaskQueue() records the memory access associated with dequeue
+      queue = pando::Cores::getTaskQueue(thisPlace);
       task = queue->tryDequeue(ctok);
 
       if (!task.has_value()) {

--- a/pando-rt/src/start.cpp
+++ b/pando-rt/src/start.cpp
@@ -61,7 +61,7 @@ extern "C" int __start(int argc, char** argv) {
       if (!task.has_value()) {
 #ifdef PANDO_RT_USE_BACKEND_PREP
         pando::Cores::workStealing(task, failState, idleCount, idleTimer);
-#elif defined(PANDO_RT_USE_BACKEND_DRVX) && defined(PANDO_RT_WORK_STEALING)
+#elif defined(PANDO_RT_USE_BACKEND_DRVX) && defined(PANDO_RT_DRVX_WORK_STEALING)
         pando::Cores::workStealing(task);
 #endif
       }

--- a/pando-rt/src/start.cpp
+++ b/pando-rt/src/start.cpp
@@ -46,8 +46,8 @@ extern "C" int __start(int argc, char** argv) {
     auto ctok = queue->makeConsumerToken();
 
     std::optional<pando::Task> task = std::nullopt;
-    
-#ifdef PANDO_RT_USE_BACKEND_PREP
+
+#if defined(PANDO_RT_USE_BACKEND_PREP)
     SchedulerFailState failState = SchedulerFailState::YIELD;
 #endif
 
@@ -58,7 +58,7 @@ extern "C" int __start(int argc, char** argv) {
       if (!task.has_value()) {
 #ifdef PANDO_RT_USE_BACKEND_PREP
         pando::Cores::workStealing(task, failState, idleCount, idleTimer);
-#elif defined(PANDO_RT_USE_BACKEND_DRVX)
+#elif defined(PANDO_RT_USE_BACKEND_DRVX) && defined(PANDO_RT_WORK_STEALING)
         pando::Cores::workStealing(task);
 #endif
       }

--- a/pando-rt/src/start.hpp
+++ b/pando-rt/src/start.hpp
@@ -4,6 +4,17 @@
 #ifndef PANDO_RT_SRC_START_HPP_
 #define PANDO_RT_SRC_START_HPP_
 
+#include <cstdint>
+
+constexpr bool IDLE_TIMER_ENABLE = false;
+
+constexpr std::uint64_t STEAL_THRESH_HOLD_SIZE = 16;
+
+enum SchedulerFailState{
+  YIELD,
+  STEAL,
+};
+
 /**
  * @brief Start function for each hart.
  *


### PR DESCRIPTION
<!--
  ~ SPDX-License-Identifier: MIT
  ~ Copyright (c) 2023. University of Texas at Austin. All rights reserved.
  -->

# Description

## Important -- Read Before Creating a Pull Request

## PR description

1. hartYield for DrvX is incorporated into *coreActive, so it does not need scheduler FailState to ping-pong between yield and steal state.
2. Add a cmake flag to turn on and off work stealing for DrvX (default is off)
3. Take the overhead of reading your own task queue into account

## Checklist

- [ ] The additions follow the code standards in the [developer guide](pando-rt/docs/developer.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
