### PR TITLE
fix overlapping prep timers

### DIFF
--- a/pando-rt/src/init.cpp
+++ b/pando-rt/src/init.cpp
@@ -198,29 +198,35 @@ int main(int argc, char* argv[]) {
   rc = getrusage(RUSAGE_SELF, &end);
   if(rc != 0) {PANDO_ABORT("GETRUSAGE FAILED");}
   auto thisPlace = pando::getCurrentPlace();
-  SPDLOG_WARN("Total time on node: {}, was {}ns",
-      thisPlace.node.id,
-      end.ru_utime.tv_sec * 1000000000 + end.ru_utime.tv_usec * 1000 -
-      (start.ru_utime.tv_sec * 1000000000 + start.ru_utime.tv_usec * 1000) +
-      end.ru_stime.tv_sec * 1000000000 + end.ru_stime.tv_usec * 1000 -
-      (start.ru_stime.tv_sec * 1000000000 + start.ru_stime.tv_usec * 1000));
-  for(std::uint64_t i = 0; i < std::uint64_t(dims.core.x + 1); i++) {
-    SPDLOG_WARN("Idle time on node: {}, core: {} was {}",
-        thisPlace.node.id,
-        std::int8_t((i == std::uint64_t(dims.core.x)) ? -1 : i),
-        idleCount.get(i));
-    SPDLOG_WARN("Pointer time on node: {}, core: {} was {}",
-        thisPlace.node.id,
-        std::int8_t((i == std::uint64_t(dims.core.x)) ? -1 : i),
-        pointerCount.get(i));
-    SPDLOG_WARN("Scheduler time on node: {}, core: {} was {}",
-        thisPlace.node.id,
-        std::int8_t((i == std::uint64_t(dims.core.x)) ? -1 : i),
-        schedulerCount.get(i));
-    SPDLOG_WARN("DoAll time on node: {}, core: {} was {}",
-        thisPlace.node.id,
-        std::int8_t((i == std::uint64_t(dims.core.x)) ? -1 : i),
-        doAllCount.get(i));
+  for (std::int64_t j = 0; j < std::int64_t(dims.node.id); j++) {
+    if (j == thisPlace.node.id) {
+      SPDLOG_WARN("Total time on node: {}, was {}ns",
+          thisPlace.node.id,
+          end.ru_utime.tv_sec * 1000000000 + end.ru_utime.tv_usec * 1000 -
+          (start.ru_utime.tv_sec * 1000000000 + start.ru_utime.tv_usec * 1000) +
+          end.ru_stime.tv_sec * 1000000000 + end.ru_stime.tv_usec * 1000 -
+          (start.ru_stime.tv_sec * 1000000000 + start.ru_stime.tv_usec * 1000));
+      for(std::uint64_t i = 0; i < std::uint64_t(dims.core.x + 1); i++) {
+        SPDLOG_WARN("Idle time on node: {}, core: {} was {}",
+            thisPlace.node.id,
+            std::int8_t((i == std::uint64_t(dims.core.x)) ? -1 : i),
+            idleCount.get(i));
+        SPDLOG_WARN("Pointer time on node: {}, core: {} was {}",
+            thisPlace.node.id,
+            std::int8_t((i == std::uint64_t(dims.core.x)) ? -1 : i),
+            pointerCount.get(i));
+        SPDLOG_WARN("Scheduler time on node: {}, core: {} was {}",
+            thisPlace.node.id,
+            std::int8_t((i == std::uint64_t(dims.core.x)) ? -1 : i),
+            schedulerCount.get(i));
+        SPDLOG_WARN("DoAll time on node: {}, core: {} was {}",
+            thisPlace.node.id,
+            std::int8_t((i == std::uint64_t(dims.core.x)) ? -1 : i),
+            doAllCount.get(i));
+      }
+    }
+
+    pando::Nodes::barrier();
   }
 
 


### PR DESCRIPTION
Previously, timer outputs from separate PXNs would overlap, making the output unusable. Adds a simple barrier to ensure each PXN waits for its turn when logging timer info.
