### PR TITLE
Add arguments to control the network bandwidth number in a reasonable way

### DIFF
--- a/microbench/bfs/include/pando-bfs-galois/sssp.hpp
+++ b/microbench/bfs/include/pando-bfs-galois/sssp.hpp
@@ -146,8 +146,6 @@ pando::Status SSSP_DLCSR(
       }));
   PANDO_CHECK(wg.wait());
 #endif
-  PANDO_DRV_SET_STAGE_EXEC_COMP();
-  PANDO_DRV_CLEAR_BYPASS_FLAG();
 
   while (!IsactiveIterationEmpty(phbfs)) {
 #ifdef DEBUG_PRINTS
@@ -323,8 +321,6 @@ pando::Status SSSPMDLCSR(G& graph, std::uint64_t src, HostLocalStorage<MDWorkLis
       }));
   PANDO_CHECK(wg.wait());
 #endif
-  PANDO_DRV_SET_STAGE_EXEC_COMP();
-  PANDO_DRV_CLEAR_BYPASS_FLAG();
 
   *active = true;
   while (*active) {

--- a/microbench/bfs/src/main.cpp
+++ b/microbench/bfs/src/main.cpp
@@ -64,6 +64,9 @@ void HBMainDLCSR(pando::Vector<std::uint64_t> srcVertices, std::uint64_t numVert
 
   PANDO_CHECK(next.initialize());
 
+  PANDO_DRV_SET_STAGE_EXEC_COMP();
+  PANDO_DRV_CLEAR_BYPASS_FLAG();
+
   // Run BFS
   for (std::uint64_t srcVertex : srcVertices) {
     std::cout << "Source Vertex is " << srcVertex << std::endl;
@@ -136,6 +139,10 @@ void HBMainMDLCSR(pando::Vector<std::uint64_t> srcVertices, std::uint64_t numVer
           PANDO_CHECK(fmap(fmap(toWriteLocal, operator[], i), initialize, 0));
         }
       }));
+
+  PANDO_DRV_SET_STAGE_EXEC_COMP();
+  PANDO_DRV_CLEAR_BYPASS_FLAG();
+
   // Run BFS
   for (std::uint64_t srcVertex : srcVertices) {
     std::cout << "Source Vertex is " << srcVertex << std::endl;

--- a/pando-drv/tests/drv.py
+++ b/pando-drv/tests/drv.py
@@ -167,21 +167,24 @@ CHIPRTR_ID = 1024*1024
 ###################
 # Bandwidth Numbers #
 ###################
-COMMAND_BW = format_bw(arguments.network_issue_rate * freq_str_to_hz(arguments.command_clock))
-CORE_BW = format_bw(arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock))
+COMMAND_BW_NUM = arguments.network_issue_rate * freq_str_to_hz(arguments.command_clock)
+COMMAND_BW = format_bw(COMMAND_BW_NUM)
+CORE_BW_NUM = arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock)
+CORE_BW = format_bw(CORE_BW_NUM)
 SCRATCHPAD_BW = format_bw(arguments.network_issue_rate * freq_str_to_hz(arguments.mem_clock))
 L2_MEM_BANK_BW = format_bw(arguments.pod_cores * arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock) / arguments.pod_l2sp_banks)
-L2_MEM_BW = format_bw(arguments.pod_cores * arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock))
+L2_MEM_BW_NUM = arguments.pod_cores * arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock)
+L2_MEM_BW = format_bw(L2_MEM_BW_NUM)
 MAIN_MEM_BANK_BW = format_bw(arguments.pxn_pods * arguments.pod_cores * arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock) / arguments.pxn_dram_banks)
-MAIN_MEM_BW = format_bw(arguments.pxn_pods * arguments.pod_cores * arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock))
+MAIN_MEM_BW_NUM = arguments.pxn_pods * arguments.pod_cores * arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock)
+MAIN_MEM_BW = format_bw(MAIN_MEM_BW_NUM)
 if arguments.network_bw_config == "manual":
     ONCHIP_RTR_BW = arguments.network_onchip_bw
-else:
-    ONCHIP_RTR_BW = 2 * (COMMAND_BW + arguments.pxn_pods*arguments.pod_cores*CORE_BW + arguments.pxn_pods*L2_MEM_BW + MAIN_MEM_BW)
-if arguments.network_bw_config == "manual":
     OFFCHIP_RTR_BW = arguments.network_offchip_bw
 else:
-    OFFCHIP_RTR_BW = arguments.num_pxn * ONCHIP_RTR_BW
+    ONCHIP_RTR_BW_NUM = 2 * (COMMAND_BW_NUM + arguments.pxn_pods*arguments.pod_cores*CORE_BW_NUM + arguments.pxn_pods*L2_MEM_BW_NUM + MAIN_MEM_BW_NUM)
+    ONCHIP_RTR_BW = format_bw(ONCHIP_RTR_BW_NUM)
+    OFFCHIP_RTR_BW = format_bw(arguments.num_pxn * ONCHIP_RTR_BW_NUM)
 
 SYSCONFIG = {
     "sys_num_pxn" : 1,

--- a/pando-drv/tests/drv.py
+++ b/pando-drv/tests/drv.py
@@ -53,6 +53,7 @@ parser.add_argument("--pxn-dram-banks", type=int, default=8, help="number of dra
 parser.add_argument("--pxn-dram-size", type=int, default=1024**3, help="size of main memory per pxn (max {} bytes)".format(8*1024*1024*1024))
 parser.add_argument("--pxn-dram-interleave", type=int, default=0, help="interleave size of dram addresses (defaults to no  interleaving)")
 
+parser.add_argument("--network-base-bw", type=str, default="1GB/s", help="on chip network base bandwidth")
 parser.add_argument("--network-onchip-buffer-size", type=str, default="1MB", help="on chip network input / output buffer size")
 parser.add_argument("--network-offchip-buffer-size", type=str, default="64MB", help="off chip network input / output buffer size")
 
@@ -302,7 +303,7 @@ class CommandProcessor(object):
         self.core_nic = self.core_iface.setSubComponent("memlink", "memHierarchy.MemNIC")
         self.core_nic.addParams({
             "group" : 0,
-            "network_bw" : "1024GB/s",
+            "network_bw" : arguments.network_base_bw,
             "network_input_buffer_size" : arguments.network_onchip_buffer_size,
             "network_output_buffer_size" : arguments.network_onchip_buffer_size,
             "destinations" : "0,1,2",

--- a/pando-drv/tests/drv.py
+++ b/pando-drv/tests/drv.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023 University of Washington
 import sst
 import argparse
+import re
 
 # common functions
 ADDR_TYPE_HI,ADDR_TYPE_LO     = (63, 58)
@@ -19,6 +20,39 @@ def set_bits(word, hi, lo, value):
     word &= ~(mask << lo)
     word |= (value & mask) << lo
     return word
+
+# Function to convert frequency string to Hz
+def freq_str_to_hz(frequency_str):
+    # Regular expression to match frequency and its unit
+    match = re.match(r"(\d+)([GMK]Hz)", frequency_str)
+    if not match:
+        raise ValueError("Invalid frequency format")
+
+    value = int(match.group(1))
+    unit = match.group(2)
+
+    # Convert value to Hz based on unit
+    if unit == "GHz":
+        return value * 1e9
+    elif unit == "MHz":
+        return value * 1e6
+    elif unit == "KHz":
+        return value * 1e3
+    else:
+        raise ValueError("Unsupported frequency unit")
+
+# Function to format bandwidth with appropriate units
+def format_bw(bandwidth):
+    if bandwidth >= 1e12:
+        return f"{bandwidth / 1e12:.2f}TB/s"
+    elif bandwidth >= 1e9:
+        return f"{bandwidth / 1e9:.2f}GB/s"
+    elif bandwidth >= 1e6:
+        return f"{bandwidth / 1e6:.2f}MB/s"
+    elif bandwidth >= 1e3:
+        return f"{bandwidth / 1e3:.2f}KB/s"
+    else:
+        return f"{bandwidth:.2f}B/s"
 
 ################################
 # parse command line arguments #
@@ -45,6 +79,8 @@ parser.add_argument("--num-pxn", type=int, default=1, help="number of pxns")
 parser.add_argument("--core-threads", type=int, default=16, help="number of threads per core")
 parser.add_argument("--core-clock", type=str, default="1GHz", help="clock frequency of cores")
 parser.add_argument("--core-max-idle", type=int, default=1, help="max idle time of cores")
+parser.add_argument("--command-clock", type=str, default="2GHz", help="clock frequency of command processors")
+parser.add_argument("--mem-clock", type=str, default="1GHz", help="clock frequency of memory components")
 
 parser.add_argument("--pod-l2sp-banks", type=int, default=8, help="number of l2sp banks per pod")
 parser.add_argument("--pod-l2sp-interleave", type=int, default=0, help="interleave size of l2sp addresses (defaults to no  interleaving)")
@@ -53,7 +89,10 @@ parser.add_argument("--pxn-dram-banks", type=int, default=8, help="number of dra
 parser.add_argument("--pxn-dram-size", type=int, default=1024**3, help="size of main memory per pxn (max {} bytes)".format(8*1024*1024*1024))
 parser.add_argument("--pxn-dram-interleave", type=int, default=0, help="interleave size of dram addresses (defaults to no  interleaving)")
 
-parser.add_argument("--network-base-bw", type=str, default="1GB/s", help="on chip network base bandwidth")
+parser.add_argument("--network-issue-rate", type=int, default=8, help="core memory operation issue rate in bytes")
+parser.add_argument("--network-bw-config", type=str, default="auto", choices=['auto', 'manual'], help="network bandwidth configuration type")
+parser.add_argument("--network-onchip-bw", type=str, default="1GB/s", help="network on chip router bandwidth")
+parser.add_argument("--network-offchip-bw", type=str, default="4GB/s", help="network off chip router bandwidth")
 parser.add_argument("--network-onchip-buffer-size", type=str, default="1MB", help="on chip network input / output buffer size")
 parser.add_argument("--network-offchip-buffer-size", type=str, default="64MB", help="off chip network input / output buffer size")
 
@@ -124,6 +163,25 @@ CORE_L1SP_SIZE = (1<<17)
 COMPUTETILE_RTR_ID = 0
 SHAREDMEM_RTR_ID = 1024
 CHIPRTR_ID = 1024*1024
+
+###################
+# Bandwidth Numbers #
+###################
+COMMAND_BW = format_bw(arguments.network_issue_rate * freq_str_to_hz(arguments.command_clock))
+CORE_BW = format_bw(arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock))
+SCRATCHPAD_BW = format_bw(arguments.network_issue_rate * freq_str_to_hz(arguments.mem_clock))
+L2_MEM_BANK_BW = format_bw(arguments.pod_cores * arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock) / arguments.pod_l2sp_banks)
+L2_MEM_BW = format_bw(arguments.pod_cores * arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock))
+MAIN_MEM_BANK_BW = format_bw(arguments.pxn_pods * arguments.pod_cores * arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock) / arguments.pxn_dram_banks)
+MAIN_MEM_BW = format_bw(arguments.pxn_pods * arguments.pod_cores * arguments.network_issue_rate * freq_str_to_hz(arguments.core_clock))
+if arguments.network_bw_config == "manual":
+    ONCHIP_RTR_BW = arguments.network_onchip_bw
+else:
+    ONCHIP_RTR_BW = 2 * (COMMAND_BW + arguments.pxn_pods*arguments.pod_cores*CORE_BW + arguments.pxn_pods*L2_MEM_BW + MAIN_MEM_BW)
+if arguments.network_bw_config == "manual":
+    OFFCHIP_RTR_BW = arguments.network_offchip_bw
+else:
+    OFFCHIP_RTR_BW = arguments.num_pxn * ONCHIP_RTR_BW
 
 SYSCONFIG = {
     "sys_num_pxn" : 1,
@@ -276,7 +334,7 @@ class CommandProcessor(object):
         self.core.addParams({
             "verbose"   : arguments.verbose,
             "threads"   : 1,
-            "clock"     : "2GHz",
+            "clock"     : arguments.command_clock,
             "executable": arguments.with_command_processor,
             "argv" : ' '.join(argv), # cp its own exe as first arg, then same argv as the main program
             "max_idle" : 100//8, # turn clock offf after idle for 1 us
@@ -303,7 +361,7 @@ class CommandProcessor(object):
         self.core_nic = self.core_iface.setSubComponent("memlink", "memHierarchy.MemNIC")
         self.core_nic.addParams({
             "group" : 0,
-            "network_bw" : arguments.network_base_bw,
+            "network_bw" : COMMAND_BW,
             "network_input_buffer_size" : arguments.network_onchip_buffer_size,
             "network_output_buffer_size" : arguments.network_onchip_buffer_size,
             "destinations" : "0,1,2",

--- a/pando-drv/tests/drv_memory.py
+++ b/pando-drv/tests/drv_memory.py
@@ -22,7 +22,7 @@ class SharedMemoryBank(object):
         self.name = self.make_name(*args, **kwargs)
         self.memctrl = sst.Component("{}_memctrl_{}".format(self.name,self.id), "memHierarchy.MemController")
         self.memctrl.addParams({
-            "clock" : arguments.mem_clock,
+            "request_width" : arguments.mem_request_width,
             "addr_range_start" : self.address_range.start,
             "addr_range_end"   : self.address_range.end,
             "interleave_size" :  str(self.address_range.interleave_size) + 'B',
@@ -116,6 +116,10 @@ class L2MemoryBank(SharedMemoryBank):
     def __init__(self, bank, pod=0, pxn=0):
         super().__init__(bank, pod, pxn)
 
+        self.memctrl.addParams({
+            "clock" : L2_MEM_CLK,
+        })
+
         self.nic.addParams({
             "network_bw" : L2_MEM_BANK_BW,
         })
@@ -160,6 +164,10 @@ class L2MemoryBank(SharedMemoryBank):
 class MainMemoryBank(SharedMemoryBank):
     def __init__(self, bank, pod=0, pxn=0):
         super().__init__(bank, pod, pxn)
+
+        self.memctrl.addParams({
+            "clock" : MAIN_MEM_CLK,
+        })
 
         self.nic.addParams({
             "network_bw" : MAIN_MEM_BANK_BW,

--- a/pando-drv/tests/drv_memory.py
+++ b/pando-drv/tests/drv_memory.py
@@ -22,7 +22,7 @@ class SharedMemoryBank(object):
         self.name = self.make_name(*args, **kwargs)
         self.memctrl = sst.Component("{}_memctrl_{}".format(self.name,self.id), "memHierarchy.MemController")
         self.memctrl.addParams({
-            "clock" : "1GHz",
+            "clock" : arguments.mem_clock,
             "addr_range_start" : self.address_range.start,
             "addr_range_end"   : self.address_range.end,
             "interleave_size" :  str(self.address_range.interleave_size) + 'B',
@@ -45,7 +45,6 @@ class SharedMemoryBank(object):
         self.nic = self.memctrl.setSubComponent("cpulink", "memHierarchy.MemNIC")
         self.nic.addParams({
             "group" : 2,
-            "network_bw" : arguments.network_base_bw,
             "network_input_buffer_size" : arguments.network_onchip_buffer_size,
             "network_output_buffer_size" : arguments.network_onchip_buffer_size,
             "verbose_level": arguments.verbose_memory,
@@ -59,8 +58,6 @@ class SharedMemoryBank(object):
             "num_ports" : 2,
             "topology" : "merlin.singlerouter",
             # performance models
-            "xbar_bw" : arguments.network_base_bw,
-            "link_bw" : arguments.network_base_bw,
             "flit_size" : "8B",
             "input_buf_size" : arguments.network_onchip_buffer_size,
             "output_buf_size" : arguments.network_onchip_buffer_size,
@@ -119,6 +116,15 @@ class L2MemoryBank(SharedMemoryBank):
     def __init__(self, bank, pod=0, pxn=0):
         super().__init__(bank, pod, pxn)
 
+        self.nic.addParams({
+            "network_bw" : L2_MEM_BANK_BW,
+        })
+
+        self.mem_rtr.addParams({
+            "xbar_bw" : L2_MEM_BANK_BW,
+            "link_bw" : L2_MEM_BANK_BW,
+        })
+
     def make_id(self, bank, pod=0, pxn=0):
         """
         @brief return a unique integer
@@ -154,6 +160,15 @@ class L2MemoryBank(SharedMemoryBank):
 class MainMemoryBank(SharedMemoryBank):
     def __init__(self, bank, pod=0, pxn=0):
         super().__init__(bank, pod, pxn)
+
+        self.nic.addParams({
+            "network_bw" : MAIN_MEM_BANK_BW,
+        })
+
+        self.mem_rtr.addParams({
+            "xbar_bw" : MAIN_MEM_BANK_BW,
+            "link_bw" : MAIN_MEM_BANK_BW,
+        })
 
     def make_id(self, bank, pod=0, pxn=0):
         """

--- a/pando-drv/tests/drv_memory.py
+++ b/pando-drv/tests/drv_memory.py
@@ -45,7 +45,7 @@ class SharedMemoryBank(object):
         self.nic = self.memctrl.setSubComponent("cpulink", "memHierarchy.MemNIC")
         self.nic.addParams({
             "group" : 2,
-            "network_bw" : "256GB/s",
+            "network_bw" : arguments.network_base_bw,
             "network_input_buffer_size" : arguments.network_onchip_buffer_size,
             "network_output_buffer_size" : arguments.network_onchip_buffer_size,
             "verbose_level": arguments.verbose_memory,
@@ -59,8 +59,8 @@ class SharedMemoryBank(object):
             "num_ports" : 2,
             "topology" : "merlin.singlerouter",
             # performance models
-            "xbar_bw" : "1024GB/s",
-            "link_bw" : "1024GB/s",
+            "xbar_bw" : arguments.network_base_bw,
+            "link_bw" : arguments.network_base_bw,
             "flit_size" : "8B",
             "input_buf_size" : arguments.network_onchip_buffer_size,
             "output_buf_size" : arguments.network_onchip_buffer_size,

--- a/pando-drv/tests/drv_pandohammer.py
+++ b/pando-drv/tests/drv_pandohammer.py
@@ -39,8 +39,8 @@ def MakePANDOHammer(make_tile):
             "num_ports" : PODS * (CORES + POD_L2_BANKS) + (1 if arguments.with_command_processor else 0) + PXN_MAINMEM_BANKS + PXNS - 1, # If number of PXNS is equal to 1 we do not need additional port. Hence -1
             "topology" : "merlin.singlerouter",
             # performance models
-            "xbar_bw" : (PODS * (CORES + POD_L2_BANKS) + (1 if arguments.with_command_processor else 0) + PXN_MAINMEM_BANKS + PXNS - 1) * arguments.network_base_bw,
-            "link_bw" : (PODS * (CORES + POD_L2_BANKS) + (1 if arguments.with_command_processor else 0) + PXN_MAINMEM_BANKS + PXNS - 1) * arguments.network_base_bw,
+            "xbar_bw" : ONCHIP_RTR_BW,
+            "link_bw" : ONCHIP_RTR_BW,
             "flit_size" : "8B",
             "input_buf_size" : arguments.network_onchip_buffer_size,
             "output_buf_size" : arguments.network_onchip_buffer_size,
@@ -72,7 +72,7 @@ def MakePANDOHammer(make_tile):
                     "translator" : "memHierarchy.MemNetBridge",
                     "debug" : 1,
                     "debug_level" : 10,
-                    "network_bw" : arguments.network_base_bw,
+                    "network_bw" : CORE_BW,
                     "network_input_buffer_size" : arguments.network_onchip_buffer_size,
                     "network_output_buffer_size" : arguments.network_onchip_buffer_size,
                 })
@@ -95,7 +95,7 @@ def MakePANDOHammer(make_tile):
                     "translator" : "memHierarchy.MemNetBridge",
                     "debug" : 1,
                     "debug_level" : 10,
-                    "network_bw" : arguments.network_base_bw,
+                    "network_bw" : L2_MEM_BANK_BW,
                     "network_input_buffer_size" : arguments.network_onchip_buffer_size,
                     "network_output_buffer_size" : arguments.network_onchip_buffer_size,
                 })
@@ -118,7 +118,7 @@ def MakePANDOHammer(make_tile):
                 "translator" : "memHierarchy.MemNetBridge",
                 "debug" : 1,
                 "debug_level" : 10,
-                "network_bw" : arguments.network_base_bw,
+                "network_bw" : MAIN_MEM_BANK_BW,
                 "network_input_buffer_size" : arguments.network_onchip_buffer_size,
                 "network_output_buffer_size" : arguments.network_onchip_buffer_size,
             })
@@ -151,8 +151,8 @@ def MakePANDOHammer(make_tile):
             "num_ports" : PXNS,
             "topology" : "merlin.singlerouter",
             # performance models
-            "xbar_bw" : PXNS * arguments.network_base_bw,
-            "link_bw" : PXNS * arguments.network_base_bw,
+            "xbar_bw" : OFFCHIP_RTR_BW,
+            "link_bw" : OFFCHIP_RTR_BW,
             "flit_size" : "8B",
             "input_buf_size" : arguments.network_offchip_buffer_size,
             "output_buf_size" : arguments.network_offchip_buffer_size,
@@ -169,7 +169,7 @@ def MakePANDOHammer(make_tile):
                 "translator" : "memHierarchy.MemNetBridge",
                 "debug" : 1,
                 "debug_level" : 10,
-                "network_bw" : arguments.network_base_bw,
+                "network_bw" : ONCHIP_RTR_BW,
                 "network_input_buffer_size" : arguments.network_offchip_buffer_size,
                 "network_output_buffer_size" : arguments.network_offchip_buffer_size,
             })

--- a/pando-drv/tests/drv_pandohammer.py
+++ b/pando-drv/tests/drv_pandohammer.py
@@ -39,8 +39,8 @@ def MakePANDOHammer(make_tile):
             "num_ports" : PODS * (CORES + POD_L2_BANKS) + (1 if arguments.with_command_processor else 0) + PXN_MAINMEM_BANKS + PXNS - 1, # If number of PXNS is equal to 1 we do not need additional port. Hence -1
             "topology" : "merlin.singlerouter",
             # performance models
-            "xbar_bw" : "256GB/s",
-            "link_bw" : "256GB/s",
+            "xbar_bw" : (PODS * (CORES + POD_L2_BANKS) + (1 if arguments.with_command_processor else 0) + PXN_MAINMEM_BANKS + PXNS - 1) * arguments.network_base_bw,
+            "link_bw" : (PODS * (CORES + POD_L2_BANKS) + (1 if arguments.with_command_processor else 0) + PXN_MAINMEM_BANKS + PXNS - 1) * arguments.network_base_bw,
             "flit_size" : "8B",
             "input_buf_size" : arguments.network_onchip_buffer_size,
             "output_buf_size" : arguments.network_onchip_buffer_size,
@@ -72,7 +72,7 @@ def MakePANDOHammer(make_tile):
                     "translator" : "memHierarchy.MemNetBridge",
                     "debug" : 1,
                     "debug_level" : 10,
-                    "network_bw" : "256GB/s",
+                    "network_bw" : arguments.network_base_bw,
                     "network_input_buffer_size" : arguments.network_onchip_buffer_size,
                     "network_output_buffer_size" : arguments.network_onchip_buffer_size,
                 })
@@ -95,7 +95,7 @@ def MakePANDOHammer(make_tile):
                     "translator" : "memHierarchy.MemNetBridge",
                     "debug" : 1,
                     "debug_level" : 10,
-                    "network_bw" : "256GB/s",
+                    "network_bw" : arguments.network_base_bw,
                     "network_input_buffer_size" : arguments.network_onchip_buffer_size,
                     "network_output_buffer_size" : arguments.network_onchip_buffer_size,
                 })
@@ -118,7 +118,7 @@ def MakePANDOHammer(make_tile):
                 "translator" : "memHierarchy.MemNetBridge",
                 "debug" : 1,
                 "debug_level" : 10,
-                "network_bw" : "256GB/s",
+                "network_bw" : arguments.network_base_bw,
                 "network_input_buffer_size" : arguments.network_onchip_buffer_size,
                 "network_output_buffer_size" : arguments.network_onchip_buffer_size,
             })
@@ -151,8 +151,8 @@ def MakePANDOHammer(make_tile):
             "num_ports" : PXNS,
             "topology" : "merlin.singlerouter",
             # performance models
-            "xbar_bw" : "256GB/s",
-            "link_bw" : "256GB/s",
+            "xbar_bw" : PXNS * arguments.network_base_bw,
+            "link_bw" : PXNS * arguments.network_base_bw,
             "flit_size" : "8B",
             "input_buf_size" : arguments.network_offchip_buffer_size,
             "output_buf_size" : arguments.network_offchip_buffer_size,
@@ -169,7 +169,7 @@ def MakePANDOHammer(make_tile):
                 "translator" : "memHierarchy.MemNetBridge",
                 "debug" : 1,
                 "debug_level" : 10,
-                "network_bw" : "256GB/s",
+                "network_bw" : arguments.network_base_bw,
                 "network_input_buffer_size" : arguments.network_offchip_buffer_size,
                 "network_output_buffer_size" : arguments.network_offchip_buffer_size,
             })

--- a/pando-drv/tests/drv_tile.py
+++ b/pando-drv/tests/drv_tile.py
@@ -34,7 +34,8 @@ class Tile(object):
             "debug" : 0,
             "debug_level" : 0,
             "verbose" : 0,
-            "clock" : arguments.mem_clock,
+            "clock" : SCRATCHPAD_CLK,
+            "request_width" : arguments.mem_request_width,
             "addr_range_start" : self.l1sp_start(),
             "addr_range_end" :   self.l1sp_end(),
         })

--- a/pando-drv/tests/drv_tile.py
+++ b/pando-drv/tests/drv_tile.py
@@ -34,7 +34,7 @@ class Tile(object):
             "debug" : 0,
             "debug_level" : 0,
             "verbose" : 0,
-            "clock" : "1GHz",
+            "clock" : arguments.mem_clock,
             "addr_range_start" : self.l1sp_start(),
             "addr_range_end" :   self.l1sp_end(),
         })
@@ -57,7 +57,7 @@ class Tile(object):
         self.scratchpad_nic = self.scratchpad_mectrl.setSubComponent("cpulink", "memHierarchy.MemNIC")
         self.scratchpad_nic.addParams({
             "group" : 1,
-            "network_bw" : arguments.network_base_bw,
+            "network_bw" : SCRATCHPAD_BW,
             "network_input_buffer_size" : arguments.network_onchip_buffer_size,
             "network_output_buffer_size" : arguments.network_onchip_buffer_size,
         })
@@ -74,8 +74,8 @@ class Tile(object):
             "num_ports" : 3,
             "topology" : "merlin.singlerouter",
             # performance models
-            "xbar_bw" : arguments.network_base_bw,
-            "link_bw" : arguments.network_base_bw,
+            "xbar_bw" : CORE_BW,
+            "link_bw" : CORE_BW,
             "flit_size" : "8B",
             "input_buf_size" : arguments.network_onchip_buffer_size,
             "output_buf_size" : arguments.network_onchip_buffer_size,
@@ -164,12 +164,8 @@ class DrvXTile(Tile):
             "pxn" : self.pxn,
             "phase_max" : arguments.stats_preallocated_phase,
             "stack_in_l1sp" : arguments.drvx_stack_in_l1sp,
+            "clock" : arguments.core_clock,
         })
-
-        if SYSCONFIG["sys_core_clock"]:
-            self.core.addParams({
-                "clock" : SYSCONFIG["sys_core_clock"],
-            })
 
         self.core.addParams(SYSCONFIG)
         self.core.addParams(CORE_DEBUG)
@@ -189,7 +185,7 @@ class DrvXTile(Tile):
         self.core_nic = self.core_iface.setSubComponent("memlink", "memHierarchy.MemNIC")
         self.core_nic.addParams({
             "group" : 0,
-            "network_bw" : arguments.network_base_bw,
+            "network_bw" : CORE_BW,
             "network_input_buffer_size" : arguments.network_onchip_buffer_size,
             "network_output_buffer_size" : arguments.network_onchip_buffer_size,
             "destinations" : "0,1,2",
@@ -225,12 +221,8 @@ class DrvRTile(Tile):
             "core": self.id,
             "pod" : self.pod,
             "pxn" : self.pxn,
+            "clock" : arguments.core_clock,
         })
-
-        if SYSCONFIG["sys_core_clock"]:
-            self.core.addParams({
-                "clock" : SYSCONFIG["sys_core_clock"],
-            })
 
         self.core.addParams(SYSCONFIG)
         self.core.addParams(CORE_DEBUG)
@@ -241,7 +233,7 @@ class DrvRTile(Tile):
         self.core_nic = self.core_iface.setSubComponent("memlink", "memHierarchy.MemNIC")
         self.core_nic.addParams({
             "group" : 0,
-            "network_bw" : arguments.network_base_bw,
+            "network_bw" : CORE_BW,
             "network_input_buffer_size" : arguments.network_onchip_buffer_size,
             "network_output_buffer_size" : arguments.network_onchip_buffer_size,
             "destinations" : "0,1,2",

--- a/pando-drv/tests/drv_tile.py
+++ b/pando-drv/tests/drv_tile.py
@@ -57,7 +57,7 @@ class Tile(object):
         self.scratchpad_nic = self.scratchpad_mectrl.setSubComponent("cpulink", "memHierarchy.MemNIC")
         self.scratchpad_nic.addParams({
             "group" : 1,
-            "network_bw" : "1024GB/s",
+            "network_bw" : arguments.network_base_bw,
             "network_input_buffer_size" : arguments.network_onchip_buffer_size,
             "network_output_buffer_size" : arguments.network_onchip_buffer_size,
         })
@@ -74,8 +74,8 @@ class Tile(object):
             "num_ports" : 3,
             "topology" : "merlin.singlerouter",
             # performance models
-            "xbar_bw" : "1024GB/s",
-            "link_bw" : "1024GB/s",
+            "xbar_bw" : arguments.network_base_bw,
+            "link_bw" : arguments.network_base_bw,
             "flit_size" : "8B",
             "input_buf_size" : arguments.network_onchip_buffer_size,
             "output_buf_size" : arguments.network_onchip_buffer_size,
@@ -189,7 +189,7 @@ class DrvXTile(Tile):
         self.core_nic = self.core_iface.setSubComponent("memlink", "memHierarchy.MemNIC")
         self.core_nic.addParams({
             "group" : 0,
-            "network_bw" : "1024GB/s",
+            "network_bw" : arguments.network_base_bw,
             "network_input_buffer_size" : arguments.network_onchip_buffer_size,
             "network_output_buffer_size" : arguments.network_onchip_buffer_size,
             "destinations" : "0,1,2",
@@ -241,7 +241,7 @@ class DrvRTile(Tile):
         self.core_nic = self.core_iface.setSubComponent("memlink", "memHierarchy.MemNIC")
         self.core_nic.addParams({
             "group" : 0,
-            "network_bw" : "1024GB/s",
+            "network_bw" : arguments.network_base_bw,
             "network_input_buffer_size" : arguments.network_onchip_buffer_size,
             "network_output_buffer_size" : arguments.network_onchip_buffer_size,
             "destinations" : "0,1,2",

--- a/scripts/run-drv.sh
+++ b/scripts/run-drv.sh
@@ -69,6 +69,7 @@ shift $(expr $OPTIND - 1)
 PROG=$1
 shift
 
+<<comment
 ${DBG} sst -n ${HOST_THREADS} \
     "${LAUNCH_SCRIPT}" -- \
     --with-command-processor="${PROG}" \
@@ -78,13 +79,13 @@ ${DBG} sst -n ${HOST_THREADS} \
     --drvx-stack-in-l1sp \
     --pxn-dram-size=${MAIN_MEMORY_SIZE} \
     ${PROG} $@
+comment
 
-<<comment
 ${DBG} sst -n ${HOST_THREADS} \
     --verbose \
     "${LAUNCH_SCRIPT}" -- \
     --with-command-processor="${PROG}" \
-    --num-pxn=${PROCS} \
+    --num-pxn=${HOSTS} \
     --pod-cores=${CORES} \
     --core-threads=${HARTS} \
     --drvx-stack-in-l1sp \
@@ -93,4 +94,3 @@ ${DBG} sst -n ${HOST_THREADS} \
     --stats-load-level=5 \
     --stats-preallocated-phase=64 \
     ${PROG} $@
-comment

--- a/scripts/run-drv.sh
+++ b/scripts/run-drv.sh
@@ -69,7 +69,6 @@ shift $(expr $OPTIND - 1)
 PROG=$1
 shift
 
-<<comment
 ${DBG} sst -n ${HOST_THREADS} \
     "${LAUNCH_SCRIPT}" -- \
     --with-command-processor="${PROG}" \
@@ -79,8 +78,8 @@ ${DBG} sst -n ${HOST_THREADS} \
     --drvx-stack-in-l1sp \
     --pxn-dram-size=${MAIN_MEMORY_SIZE} \
     ${PROG} $@
-comment
 
+<<comment
 ${DBG} sst -n ${HOST_THREADS} \
     --verbose \
     "${LAUNCH_SCRIPT}" -- \
@@ -94,3 +93,4 @@ ${DBG} sst -n ${HOST_THREADS} \
     --stats-load-level=5 \
     --stats-preallocated-phase=64 \
     ${PROG} $@
+comment


### PR DESCRIPTION
<!--
  ~ SPDX-License-Identifier: MIT
  ~ Copyright (c) 2023. University of Texas at Austin. All rights reserved.
  -->

# Description
1. Core will issue 8B per cycle
2. BW out of all cores should match BW out of memory
    --> bank * mem BW = core * tile rtr BW
3. On chip rtr BW is accumulation of all ports
4. Off chipt rtr BW is on chip rtr BW * pxns
The above is ideal network that will probably not be network wounded but only memory bounded.
Add arguments to set on chip rtr BW and off chip rtr BW directly if want to experiment with them.


## Important -- Read Before Creating a Pull Request

## PR description

This PR _write a high-level description of your pull request_

## Checklist

- [ ] The additions follow the code standards in the [developer guide](pando-rt/docs/developer.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
